### PR TITLE
Add analysis of later edits to files

### DIFF
--- a/T231952-part-1.ipynb
+++ b/T231952-part-1.ipynb
@@ -1,0 +1,268 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Investigating claim actions\n",
+    "\n",
+    "Exploring the data for claims/labels in order to understand whether we can identify the number of statements a given file might have based on edit comments."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "You can find the source for `wmfdata` at https://github.com/neilpquinn/wmfdata\n"
+     ]
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import numpy as np\n",
+    "\n",
+    "import datetime as dt\n",
+    "\n",
+    "from wmfdata import hive, mariadb"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wmf_snapshot = '2019-11'\n",
+    "start_date = '2019-01-01' # first date of caption edits\n",
+    "end_date = '2019-12-01' # last date of caption edits (exclusive)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Investigating claim actions\n",
+    "\n",
+    "I dug into the edit comments a bit to find examples, and found that [this file](https://commons.wikimedia.org/wiki/File:Rosendahl,_Darfeld,_Ortsansicht_--_2014_--_9391.jpg) has a bunch of property edits that provided good insight into what to look for. Basically, it meant that I had to expand my search to anything that starts with \"wb\". Using that insight, the below query looks for an edit comment matching \"wb{something}-{something}:\" (anchored at the start of the comment with space for \"/* \") and aggregates over the first and second \"something\"."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "claim_query = '''\n",
+    "SELECT claim_action, claim_subaction, count(*) AS num_actions\n",
+    "FROM (\n",
+    "    SELECT\n",
+    "        regexp_extract(event_comment, \"^...(wb[^-]+)\", 1) AS claim_action,\n",
+    "        regexp_extract(event_comment, \"^...wb[^-]+-([^:]+):\", 1) AS claim_subaction\n",
+    "    FROM wmf.mediawiki_history\n",
+    "    WHERE snapshot = \"{snapshot}\"\n",
+    "    AND wiki_db = \"commonswiki\"\n",
+    "    AND event_entity = \"revision\"\n",
+    "    AND event_type = \"create\"\n",
+    "    AND event_timestamp >= \"{start_date}\"\n",
+    "    AND event_timestamp < \"{end_date}\"\n",
+    "    AND page_is_deleted = false -- only count live pages\n",
+    "    AND page_namespace = 6 -- only count files\n",
+    "    AND event_comment REGEXP \"^...(wb[^-]+)-([^:]+):\"\n",
+    ") AS ce\n",
+    "GROUP BY claim_action, claim_subaction\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 19,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "claim_counts = hive.run(\n",
+    "    [\n",
+    "        \"SET mapreduce.map.memory.mb=4096\", \n",
+    "        claim_query.format(\n",
+    "            snapshot = wmf_snapshot,\n",
+    "            start_date = start_date,\n",
+    "            end_date = end_date\n",
+    "        )\n",
+    "    ]\n",
+    ")"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 28,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>claim_action</th>\n",
+       "      <th>claim_subaction</th>\n",
+       "      <th>num_actions</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <td>2</td>\n",
+       "      <td>wbcreateclaim</td>\n",
+       "      <td>create</td>\n",
+       "      <td>1655105</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>8</td>\n",
+       "      <td>wbeditentity</td>\n",
+       "      <td>update</td>\n",
+       "      <td>261794</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>0</td>\n",
+       "      <td>wbeditentity</td>\n",
+       "      <td>update-languages</td>\n",
+       "      <td>872</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>11</td>\n",
+       "      <td>wbremoveclaims</td>\n",
+       "      <td>remove</td>\n",
+       "      <td>22021</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>3</td>\n",
+       "      <td>wbremoveclaims</td>\n",
+       "      <td>update</td>\n",
+       "      <td>14259</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>5</td>\n",
+       "      <td>wbsetclaim</td>\n",
+       "      <td>create</td>\n",
+       "      <td>537587</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>6</td>\n",
+       "      <td>wbsetclaim</td>\n",
+       "      <td>update</td>\n",
+       "      <td>40832</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>9</td>\n",
+       "      <td>wbsetdescription</td>\n",
+       "      <td>add</td>\n",
+       "      <td>2</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>10</td>\n",
+       "      <td>wbsetlabel</td>\n",
+       "      <td>add</td>\n",
+       "      <td>1631793</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>7</td>\n",
+       "      <td>wbsetlabel</td>\n",
+       "      <td>remove</td>\n",
+       "      <td>11321</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>1</td>\n",
+       "      <td>wbsetlabel</td>\n",
+       "      <td>set</td>\n",
+       "      <td>33839</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <td>4</td>\n",
+       "      <td>wbsetqualifier</td>\n",
+       "      <td>add</td>\n",
+       "      <td>107320</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "        claim_action   claim_subaction  num_actions\n",
+       "2      wbcreateclaim            create      1655105\n",
+       "8       wbeditentity            update       261794\n",
+       "0       wbeditentity  update-languages          872\n",
+       "11    wbremoveclaims            remove        22021\n",
+       "3     wbremoveclaims            update        14259\n",
+       "5         wbsetclaim            create       537587\n",
+       "6         wbsetclaim            update        40832\n",
+       "9   wbsetdescription               add            2\n",
+       "10        wbsetlabel               add      1631793\n",
+       "7         wbsetlabel            remove        11321\n",
+       "1         wbsetlabel               set        33839\n",
+       "4     wbsetqualifier               add       107320"
+      ]
+     },
+     "execution_count": 28,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "claim_counts.sort_values(['claim_action', 'claim_subaction'])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Based on this, I need to ask the developers what the various edit comments are and what they mean. Also, we know from the example file that a single edit can modify multiple properties, meaning that we cannot know how many properties a file has based on the comments."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/T231952-part-2.ipynb
+++ b/T231952-part-2.ipynb
@@ -1,0 +1,813 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Later edits to files on Commons\n",
+    "\n",
+    "In [T231952](https://phabricator.wikimedia.org/T231952), the second question is aiming to understand to what extent SDC has led to users updating structured data about existing media. It might be that users are instead adding structured data when uploading new media. This notebook seeks to answer this question.\n",
+    "\n",
+    "Similarly as we did for part 3 (it was done before this), we'll use the `mediawiki_history` table to identify structured data edits, reusing approaches from our micro-contributions analysis. These can then be compared to other types of edits in order to learn when and how structured data is used.\n",
+    "\n",
+    "Let's load some libraries and get moving."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from pyspark.sql.types import ArrayType, StringType\n",
+    "\n",
+    "from pyspark.context import SparkContext\n",
+    "from pyspark.sql.session import SparkSession\n",
+    "\n",
+    "import datetime as dt\n",
+    "\n",
+    "import pandas as pd\n",
+    "import numpy as np"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# needed to show matplot plots?\n",
+    "import matplotlib.pyplot as plt\n",
+    "\n",
+    "%matplotlib inline\n",
+    "\n",
+    "from matplotlib import colors"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sc = SparkContext.getOrCreate()\n",
+    "spark = SparkSession(sc)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Configuration variables"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wmf_snapshot = '2019-11'\n",
+    "start_date = '2019-01-01' # first creation date of files we'll be measuring\n",
+    "end_date = '2019-12-01' # last creation date"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Approach\n",
+    "\n",
+    "We'll use edit comments to identify structured data edits, and then use timestamps to measure *time to edit* since the page was created. Then, we'll plot a histogram to see if there's a reasonable cutoff we can use for separating edits happening around the initial upload from those happening later.\n",
+    "\n",
+    "For non-SDC edits, we'll look for edits that added information to a page. These edits cannot be a revert, because that would mean it's reinstating a previous state of the file, nor should it have been reverted within 48 hours, as that would mean it's likely an unproductive edit.\n",
+    "\n",
+    "In both cases, we'll only look at non-bot edits to files (`page_namespace = 6`) that have not been deleted. While there might also have been valid edits to deleted files, we are mainly interested in learning whether existing pages are updated with structured data. If we were to include deleted files, I think it would be necessary to be careful about what files were included so as to only measure \"meaningful pages\" (e.g. ignoring meaningless content). Determining what did and did not warrant deletion is outside the scope of this analysis."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Cache edit data\n",
+    "\n",
+    "As we'll be exploring and most likely querying the dataset multiple times, we might as well cache a subset of `mediawiki_history`."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "edit_view_query = '''\n",
+    "CREATE TEMPORARY VIEW commons_edits\n",
+    "AS SELECT event_timestamp, page_creation_timestamp, event_comment,\n",
+    "    revision_text_bytes_diff, revision_is_identity_reverted,\n",
+    "    revision_seconds_to_identity_revert, revision_is_identity_revert\n",
+    "FROM wmf.mediawiki_history\n",
+    "WHERE snapshot = \"{snapshot}\"\n",
+    "AND wiki_db = \"commonswiki\"\n",
+    "AND event_entity = \"revision\"\n",
+    "AND event_type = \"create\"\n",
+    "AND event_timestamp >= \"{start_date}\"\n",
+    "AND event_timestamp < \"{end_date}\"\n",
+    "AND page_namespace = 6 -- only files\n",
+    "AND page_is_deleted = false -- only live pages\n",
+    "AND size(event_user_is_bot_by_historical) = 0 -- no bots\n",
+    "AND size(event_user_is_bot_by) = 0 -- no bots\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql(edit_view_query.format(\n",
+    "    snapshot = wmf_snapshot,\n",
+    "    start_date = start_date,\n",
+    "    end_date = end_date\n",
+    ")).collect()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "[]"
+      ]
+     },
+     "execution_count": 8,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "spark.sql('CACHE TABLE commons_edits').collect()"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time to edit for SDC\n",
+    "\n",
+    "We'll grab data and plot a histogram for time from page creation to the first SDC edit for files that had either captions or statements added."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Time between page creation and edit \n",
+    "\n",
+    "time_to_sdc_query = '''\n",
+    "SELECT unix_timestamp(event_timestamp) - unix_timestamp(page_creation_timestamp) AS time_to_edit\n",
+    "FROM commons_edits\n",
+    "WHERE event_comment REGEXP \"^...wbsetclaim-create:.*?Special:EntityPage/(P\\\\\\\\d+)\"\n",
+    "OR event_comment REGEXP \"^...wbsetlabel-add:\"\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 10,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_to_sdc = spark.sql(time_to_sdc_query).toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time_to_edit</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>147.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>12.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   time_to_edit\n",
+       "0         147.0\n",
+       "1           2.0\n",
+       "2           2.0\n",
+       "3           2.0\n",
+       "4          12.0"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "time_to_sdc.loc[time_to_sdc['time_to_edit'] > 0].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 12,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAkUAAAGgCAYAAACkHxNtAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3X10VPWdP/D3ZDIPmUkmCRASCAGysoA8aIAgRgvWSpPa\n0PUBu+qx2kbUIz/QYloUW4tFdwvq8aFWlLq2wjldWvV01RWUwMEaHjIqBFkgSqxUQIwhUTKZZJKZ\nSWbm90eca4bMDfnmJp1v8n2/zulpcucy+bzfd2K+uZM7Y4pEIhEQERERKS4p0QMQERERyYCLIiIi\nIiJwUUREREQEgIsiIiIiIgBcFBEREREB4KKIiIiICAAXRUREREQAuCgiIiIiAsBFEREREREALoqI\niIiIAHBRRERERAQASE70ADILh8Ooq6tDWloaTCZToschIiKiPohEImhpacHYsWORlNT38z9cFPWi\nrq4OeXl5iR6DiIiI+uGzzz7DuHHj+rw/F0W9SEtLA9BVqsvlSvA0ZITH48HevXtx6aWXIiMjI9Hj\nDHvsWx+7EaNCX7JlNDKPLFm8Xi/y8vK0n+N9xUVRL6JPmblcLi6KhoHs7GxkZGTwWP6TsG997EaM\nCn3JltHIPDJlEf3TF1MkEokM0ixDntfrRXp6Opqbm6U4uERERHRu/f35zavPiIiIiMBFESkiHA6j\nvb0d4XA40aMogX3rYzdiVOhLtoxG5pEtiyguikgJXq8X27dvh9frTfQoSmDf+tiNGBX6ki2jkXlk\nyyKKiyIiIiIicFFEijCZTEhOTuaLcP6TsG997EaMCn3JltHIPLJlEcWrz3rBq8+IiIiGHl59RkRE\nRGQAF0VERERE4KKIFOHxePD666/D4/EkehQlsG997EaMCn3JltHIPLJlEcVFERERERG4KCIiIiIC\nwKvPesWrz4aPSCSCzs7OIX2p6FDCvvWxGzEq9CVbRiPzyJKlvz+/kwdxJiJpmEwmWCyWRI+hDPat\nj92IUaEv2TIamUe2LKK4KEqgiau29vvfHl9XOoCTEBEREf+miJTg9XpRUVExZN+PZ6hh3/rYjRgV\n+pIto5F5ZMsiiosiUkI4HIbf7x+y79w81LBvfexGjAp9yZbRyDyyZRHFRRERERERePVZrwb76jP+\nTdE/TygUgs/ng9PphNlsTvQ4wx771sduxKjQl2wZjcwjSxZefUbUC7PZzJdV+Cdi3/rYjRgV+pIt\no5F5ZMsiik+fEREREYGLIlJES0sLdu3ahZaWlkSPogT2rY/diFGhL9kyGplHtiyiuCgiJYRCITQ1\nNSEUCiV6FCWwb33sRowKfcmW0cg8smURxUUREREREbgoIkU4nU4UFRXB6XQmehQlsG997EaMCn3J\nltHIPLJlEcWrz0gJFosFo0ePTvQYymDf+tiNGBX6ki2jkXlkyyKKZ4qIiIiIwEURKcLn82Hfvn3w\n+XyJHkUJ7FsfuxGjQl+yZTQyj2xZRHFRREro6OhAXV0dOjo6Ej2KEti3PnYjRoW+ZMtoZB7Zsoji\nooiIiIgIXBSRIlJSUlBQUICUlJREj6IE9q2P3YhRoS/ZMhqZR7Ysonj1GSnBZrNhwoQJiR5DGexb\nH7sRo0JfsmU0Mo9sWUTxTBERERERuCgiRbS3t+PIkSNob29P9ChKYN/62I0YFfqSLaOReWTLIoqL\nIlJCIBDAsWPHEAgEEj2KEti3PnYjRoW+ZMtoZB7ZsojiooiIiIgIXBSRIux2O6ZMmQK73Z7oUZTA\nvvWxGzEq9CVbRiPzyJZFlCkSiUQSPYSsvF4v0tPT0dzcDJfLNeD3P3HV1n7/2+PrSgdwEiIiouGj\nvz+/eaaIiIiICFwUkSL8fj8++eQT+P3+RI+iBPatj92IUaEv2TIamUe2LKK4KCIl+P1+1NTUDNlv\n1KGGfetjN2JU6Eu2jEbmkS2LKOFF0eeff44f/ehHGDlyJFJSUjBz5kzs379fuz0SiWD16tUYM2YM\nUlJSsHDhQvz973+PuY8zZ87gpptugsvlQkZGBpYsWYLW1taYfQ4dOoT58+fDbrcjLy8Pjz76aI9Z\nXnnlFUydOhV2ux0zZ87Em2++GXN7X2YhIiIiAgQXRU1NTbj00kthsVjw1ltv4cMPP8Tjjz+OzMxM\nbZ9HH30UTz/9NJ577jm89957cDqdKCkpiVk13nTTTaipqcGOHTuwZcsW7Nq1C3fccYd2u9frRXFx\nMSZMmIDq6mo89thj+PWvf43nn39e28ftduPGG2/EkiVL8MEHH+Caa67B1VdfjSNHjgjNQmqwWq0Y\nP348rFZrokdRAvvWx27EqNCXbBmNzCNbFlFCV5+tWrUKe/fuxe7du+PeHolEMHbsWPzsZz/Dz3/+\ncwBAc3MzsrOzsXHjRtxwww346KOPMG3aNOzbtw+FhYUAgG3btuH73/8+Tp06hbFjx+K5557DL3/5\nS9TX12vFrlq1Cq+99hqOHj0KALj++uvh8/mwZcsW7etffPHFKCgowIYNG/o0y7nw6jMiIqKhp78/\nv4XeEPZ///d/UVJSgh/+8IeorKxEbm4u/t//+3+4/fbbAQCffvop6uvrsXDhQu3fpKenY968eXC7\n3bjhhhvgdruRkZGhLYgAYOHChUhKSsJ7772Ha665Bm63GwsWLIhZaZaUlOCRRx5BU1MTMjMz4Xa7\nUV5eHjNfSUkJXnvttT7PcrZAIBDzKpxerxcA4PF4EA6HYbPZtHf+DQQC2suYWywWOJ1OAEBHRwd8\nPh8AwGw2Iy0tDQAQCoXQ0tICAEhKStIOkgkR5Dq/meGUz6R9nOuIwPT1p1+0AaFI1yfZKRF4PB4A\nQGpqKpKTuw5ja2srOjs7AQAOh0Prr62tDcFgEEDXa0hEXz/C7/drZ80GI1skEkFzc7OWJyMjQ/u4\nubkZ0fW4y+VCUlKS1nk4HGY2ZmM2ZmM2ZjOUrT+EFkX/+Mc/8Nxzz6G8vBy/+MUv8P777+Puu++G\nzWbDLbfcgvr6egBAdnZ2zL/Lzs7Wbquvr8fo0aNjh0hOxogRI2L2yc/P73Ef0dsyMzNRX19/zq9z\nrlnOtnbtWqxZs6bH9r1798LhcOC8887DjBkztPs/ePAgAGDs2LGYO3cugK6nGN1uNwAgMzMTCxYs\nAAD4fD5UVlYC6DpwJSUlAACrGVh5QUj7Wj91f3NI7p4egv3rT1dXm9HcddxRNjmk3df8+fMxYsQI\nAF1/h9XY2AgAKCwsRG5uLgCgtrYWJ0+eBABMnz4dkyZNAgAcP34ctbW1ADAo2To7O7XtAHDVVVdp\nH+/Zs0d7gBcXF2vfjPv379e+uQYy2+TJk9HY2Ai/3689xTpcssl43FJTU9HY2Ijjx4/jyy+/HFbZ\nBuK4ZWdnY/bs2bBarcMu20Aft2AwiPr6enzwwQfDLpusx+3UqVP9/u+kzWbDzJkzkZWVBZPJlLBs\n0W2ihJ4+s1qtKCwsRFVVlbbt7rvvxr59++B2u1FVVYVLL70UdXV1GDNmjLbPD3/4Q5jNZvzlL3/B\nb37zG2zatEk7EFFZWVl4+OGHceedd6K4uBj5+fn4/e9/r91eU1ODGTNm4KOPPsLUqVNhtVqxadMm\n3Hjjjdo+69evx8MPP4z6+vo+zXK2eGeK8vLycOLECbhcrgFfSU9ctbXfZ4oqfvotAPwtoa/ZAoEA\nKisrcckll8BisQyrbDIet9bWVlRWVmLu3LlwOBzDKpvR49bS0oIDBw7gsssuQ0ZGxrDKNhjHzePx\noLKyErNnz9b2Gy7Zosft1KlTOHDgAGbPno28vLyEZ2tsbERVVRVmz56NESNGCGVrbW1FdXU1Lrvs\nMu3pq6h/5nFraGhAdnb24D59NmbMGEybNi1m2/nnn4+//vWvAICcnBwAwOnTp2MWIg0NDSgoKND2\naWhoiLmPzs5ONDU1aWd1cnJycPr06Zh9ov/mXPt0v/1cs5zNZrPBZrP12J6RkdGjVL19LRZLzIGP\nMpvNcbdHYMIpX9xx8HmbKe720+2muPeVmpoad3+Hw6H9YOqu+wOou4HKZjLFnxPoeiozHr0Hr9Fs\n0cWuXoahnC1KxuPmcDji3tdwyDacj5ts2QAgLS0t7m1DPZvJZNIWF9H/j0pUtugvjmlpadqCKLp9\nKD0m+0Po6rNLL720xxmejz/+GBMmTAAA5OfnIycnBzt37tRu93q9eO+991BUVAQAKCoqgsfjQXV1\ntbbP22+/jXA4jHnz5mn77Nq1Cx0dHdo+O3bswJQpU7Qr3YqKimK+TnSf6NfpyyykjuTkZGRlZWm/\nddDgYt/62I0YFfqSLaOReWTLIkro6bN9+/bhkksuwZo1a/Dv//7veP/993H77bfj+eefx0033QQA\neOSRR7Bu3Tps2rQJ+fn5+NWvfoVDhw7hww8/1FZuV155JU6fPo0NGzago6MDZWVlKCwsxObNmwF0\nnVabMmUKiouLcd999+HIkSO49dZb8eSTT2qX7ldVVWHBggV45JFHUFpaqj01d+DAAe150b7M0hte\nfUZERDT0/FOuPps7dy5effVV3H///XjooYeQn5+Pp556SlsQAcC9994Ln8+HO+64Ax6PB9/61rew\nbdu2mEXIf//3f2P58uW44oorkJSUhMWLF+Ppp5/Wbk9PT0dFRQWWL1+OOXPmYNSoUVi9enXMaxld\ncskl+POf/4wHHngAv/jFL/Cv//qveO2117QFUV9nISIiIgIEzxSphmeKho/Ozk54vV64XK4he1p3\nKGHf+tiNGBX6ki2jkXlkydLfn9987zNSQmtrK3bv3t3j7WRocLBvfexGjAp9yZbRyDyyZRHFRRER\nERERuCgiRSQlJSEtLU17LQwaXOxbH7sRo0JfsmU0Mo9sWUTxb4p6wb8pIiIiGnr4N0VEREREBnBR\nREoIh8Nob2/XXj6eBhf71sduxKjQl2wZjcwjWxZRXBSRErxeL7Zv3w6v15voUZTAvvWxGzEq9CVb\nRiPzyJZFFBdFREREROCiiBRhMpmQnJwMkyn+m+zSwGLf+tiNGBX6ki2jkXlkyyKKV5/1glefERER\nDT28+oyIiIjIAC6KiIiIiMBFESnC4/Hg9ddfh8fjSfQoSmDf+tiNGBX6ki2jkXlkyyKKiyIiIiIi\ncFFEREREBIBXn/WKV58NH5FIBJ2dnUP6UtGhhH3rYzdiVOhLtoxG5pElS39/ficP4kxE0jCZTLBY\nLIkeQxnsWx+7EaNCX7JlNDKPbFlE8ekzIiIiInBRRIrwer2oqKgYsu/HM9Swb33sRowKfcmW0cg8\nsmURxUURKSEcDsPv9w/Zd24eati3PnYjRoW+ZMtoZB7ZsojiooiIiIgIvPqsV7z6bPgIhULw+Xxw\nOp0wm82JHmfYY9/62I0YFfqSLaOReWTJwqvPiHphNpsHZWFL8bFvfexGjAp9yZbRyDyyZRHFp8+I\niIiIwEURKaKlpQW7du1CS0tLokdRAvvWx27EqNCXbBmNzCNbFlFcFJESQqEQmpqaEAqFEj2KEti3\nPnYjRoW+ZMtoZB7ZsojiooiIiIgIXBSRIpxOJ4qKiuB0OhM9ihLYtz52I0aFvmTLaGQe2bKI4tVn\npASLxYLRo0cnegxlsG997EaMCn3JltHIPLJlEcUzRURERETgoogU4fP5sG/fPvh8vkSPogT2rY/d\niFGhL9kyGplHtiyiuCgiJXR0dKCurg4dHR2JHkUJ7FsfuxGjQl+yZTQyj2xZRHFRRERERAQuikgR\nKSkpKCgoQEpKSqJHUQL71sduxKjQl2wZjcwjWxZRvPqMlGCz2TBhwoREj6EM9q2P3YhRoS/ZMhqZ\nR7YsonimiIiIiAhcFJEi2tvbceTIEbS3tyd6FCWwb33sRowKfcmW0cg8smURxUURKSEQCODYsWMI\nBAKJHkUJ7FsfuxGjQl+yZTQyj2xZRHFRRERERAQuikgRdrsdU6ZMgd1uT/QoSmDf+tiNGBX6ki2j\nkXlkyyLKFIlEIokeQlZerxfp6elobm6Gy+Ua8PufuGprv//t8XWlAzgJERHR8NHfn988U0REREQE\nLopIEX6/H5988gn8fn+iR1EC+9bHbsSo0JdsGY3MI1sWUUKLol//+tcwmUwx/5s6dap2u9/vx7Jl\nyzBy5EikpqZi8eLFOH36dMx9nDx5EqWlpXA4HBg9ejRWrlyJzs7OmH3eeecdzJ49GzabDZMmTcLG\njRt7zLJ+/XpMnDgRdrsd8+bNw/vvvx9ze19mIXX4/X7U1NQM2W/UoYZ962M3YlToS7aMRuaRLYso\n4TNF06dPxxdffKH9b8+ePdpt99xzD9544w288sorqKysRF1dHa699lrt9lAohNLSUgSDQVRVVWHT\npk3YuHEjVq9ere3z6aeforS0FJdffjkOHjyIFStW4LbbbkNFRYW2z0svvYTy8nI8+OCDOHDgAC68\n8EKUlJSgoaGhz7MQERERdSe8KEpOTkZOTo72v1GjRgEAmpub8Yc//AFPPPEEvvOd72DOnDl48cUX\nUVVVhXfffRcAsH37dnz44Yf405/+hIKCAlx55ZV4+OGHsX79egSDQQDAhg0bkJ+fj8cffxznn38+\nli9fjuuuuw5PPvmkNsMTTzyB22+/HWVlZZg2bRo2bNgAh8OBP/7xj32ehdRitVoxfvx4WK3WRI+i\nBPatj92IUaEv2TIamUe2LKKE3/vs73//O8aOHQu73Y6ioiKsXbsW48ePR3V1NTo6OrBw4UJt36lT\np2L8+PFwu924+OKL4Xa7MXPmTGRnZ2v7lJSUYOnSpaipqcGsWbPgdrtj7iO6z4oVKwAAwWAQ1dXV\nuP/++7Xbk5KSsHDhQrjdbgDo0yzxBAKBmBec8nq9AACPx4NwOAybzaa9yV0gENBesdNiscDpdAIA\nOjo64PP5AABmsxlpaWkAus6StbS0aPNG/xrehAhynd/McMpn0j7OdURg+vrTL9qAUKTrk+yUCDwe\nDwAgNTUVycldh7G1tVV7KtLhcGgPyra2Nm3RabfbtUsl/X6/dopzMLJFIhE0NzdreTIyMrSPm5ub\nEb3w0eVyISkpSes8HA4PeDaHw4FZs2YhEAho3Q2XbDIet2jfra2tWt/DJdtAHLepU6cO22wDfdwc\nDgcKCgrQ3Nysfe3hki163ILBIPLz8xEMBuFwOBKezWw2a/NEIhHhbLNmzdKyJfIx2R9Ci6J58+Zh\n48aNmDJlCr744gusWbMG8+fPx5EjR1BfXw+r1RoTGgCys7NRX18PAKivr49ZEEVvj97W2z5erxft\n7e1oampCKBSKu8/Ro0e1+zjXLPGsXbsWa9as6bF97969cDgcOO+88zBjxgztaxw8eBAAMHbsWMyd\nOxcA0NTUpC3OMjMzsWDBAgCAz+dDZWUlgK4DV1JSAgCwmoGVF4S0r/VT9zeH5O7pIdi//nR1tRnN\nXccdZZND2n3Nnz8fI0aMAAAcOnQIjY2NAIDCwkLk5uYCAGpra3Hy5EkAXU9/Tpo0CQBw/Phx1NbW\nAsCgZOvs7NS2A8BVV12lfbxnzx7tAV5cXKx9M+7fv1/75mI2ZmM2ZmM2ZutPtug2UYZep8jj8WDC\nhAl44oknkJKSgrKysh4v7T137lxcccUVWLduHe644w6cOHEi5u+D2tra4HQ68dZbb+F73/seJk+e\njLKyspgzQVu3bsWiRYvQ3t6OM2fOIDc3F1VVVSgqKtL2WblyJXbv3o13330XmzdvPucs8cQ7U5SX\nl4cTJ07A5XIN+G8JE1dt7feZooqffguA/L8ByfKbq9lsRmNjI9LT07X7GS7ZZDxu4XAYjY2NcDgc\nMH39IB4u2Ywet46ODrS2tiI3NxdWq3VYZRuM4xYMBtHQ0ACbzQaLxTKsskWP25dffommpiZkZmYi\nKysr4dlaW1tRV1eHzMxMOBwOoWyhUAh+vx9ZWVmwWCwJe0w2NDQgOztb+HWKhJ8+6y4jIwOTJ0/G\nJ598gu9+97sIBoPweDwxwaODAUBOTk6Pq8SiV4R13+fsq8QaGhrgcrlgt9sxatQomM3muPt0v49z\nzRKPzWaDzWaLm/PsUvX2tVgsPc5QAV0PoHjbIzDhlC/+PJ+3meJuP91uintfqampcfd3OBwxp2Sj\nuj+AuhuobCZT/DkBID09Pe52vQev0Wwejwf79+/HZZddFnemoZwtSqbjdq6+h3K2qP4eN4/Hg0OH\nDiEzMxNWq3VYZTvbQGRra2tDdXW17mNpKGcDuo6bxWLBRx99hMsuuyzmtkRl6+zs1OaJLoiAvmU7\n+3s/kY/J/jD0OkWtra04duwYxowZgzlz5sBisWDnzp3a7R9//DFOnjypndEpKirC4cOHY64S27Fj\nB1wuF6ZNm6bt0/0+ovtE78NqtWLOnDkx+4TDYezcuVPbpy+zEBEREXUndKbo5z//OX7wgx9gwoQJ\nqKurw4MPPgiz2Ywbb7wR6enpWLJkCcrLyzFixAi4XC7cddddKCoq0v6wubi4GNOmTcPNN9+MRx99\nFPX19XjggQewbNkybcV955134ne/+x3uvfde3HrrrXj77bfx8ssvY+vWb94So7y8HLfccgsKCwtx\n0UUX4amnnoLP50NZWRkA9GkWUktycjKysrK0U7E0uNi3PnYjRoW+ZMtoZB7ZsogS+puiG264Abt2\n7cJXX32FrKwsfOtb38J//ud/4rzzzgPQ9fzkz372M/z5z39GIBBASUkJnn32WeTk5Gj3ceLECSxd\nuhTvvPMOnE4nfvzjH2PdunUxBf7tb39DeXk5PvzwQ4wbNw6/+tWv8JOf/CRmlmeeeQaPPfYY6uvr\nUVBQgKeffhrz5s3Tbu/LLOfC9z4jIiIaevr785tvCNsLLoqIiIiGHr4hLFEvOjs7cebMmR5vKUOD\ng33rYzdiVOhLtoxG5pEtiyguikgJra2t2L17N1pbWxM9ihLYtz52I0aFvmTLaGQe2bKI4qKIiIiI\nCFwUkSKSkpKQlpamvUAYDS72rY/diFGhL9kyGplHtiyi+IfWveAfWhMREQ09/ENrIiIiIgO4KCIl\nhMNhtLe3a++pQ4OLfetjN2JU6Eu2jEbmkS2LKC6KSAlerxfbt2+H1+tN9ChKYN/62I0YFfqSLaOR\neWTLIoqLIiIiIiJwUUSKMJlMSE5OhslkSvQoSmDf+tiNGBX6ki2jkXlkyyKKV5/1glefERERDT28\n+oyIiIjIAC6KiIiIiMBFESnC4/Hg9ddfh8fjSfQoSmDf+tiNGBX6ki2jkXlkyyKKiyIiIiIicFFE\nREREBIBXn/WKV58NH5FIBJ2dnUP6UtGhhH3rYzdiVOhLtoxG5pElS39/ficP4kxE0jCZTLBYLIke\nQxnsWx+7EaNCX7JlNDKPbFlE8ekzIiIiInBRRIrwer2oqKgYsu/HM9Swb33sRowKfcmW0cg8smUR\nxUURKSEcDsPv9w/Zd24eati3PnYjRoW+ZMtoZB7ZsojiooiIiIgIvPqsV7z6bPgIhULw+XxwOp0w\nm82JHmfYY9/62I0YFfqSLaOReWTJwqvPiHphNpsHZWFL8bFvfexGjAp9yZbRyDyyZRHFp8+IiIiI\nwEURKaKlpQW7du1CS0tLokdRAvvWx27EqNCXbBmNzCNbFlFcFJESQqEQmpqaEAqFEj2KEti3PnYj\nRoW+ZMtoZB7ZsojiooiIiIgIXBSRIpxOJ4qKiuB0OhM9ihLYtz52I0aFvmTLaGQe2bKI4tVnpASL\nxYLRo0cnegxlsG997EaMCn3JltHIPLJlEcUzRURERETgoogU4fP5sG/fPvh8vkSPogT2rY/diFGh\nL9kyGplHtiyiuCgiJXR0dKCurg4dHR2JHkUJ7FsfuxGjQl+yZTQyj2xZRHFRRERERAQuikgRKSkp\nKCgoQEpKSqJHUQL71sduxKjQl2wZjcwjWxZRvPqMlGCz2TBhwoREj6EM9q2P3YhRoS/ZMhqZR7Ys\nonimiIiIiAhcFJEi2tvbceTIEbS3tyd6FCWwb33sRowKfcmW0cg8smURxUURKSEQCODYsWMIBAKJ\nHkUJ7FsfuxGjQl+yZTQyj2xZRHFRRERERAQuikgRdrsdU6ZMgd1uT/QoSmDf+tiNGBX6ki2jkXlk\nyyLKFIlEIokeQlZerxfp6elobm6Gy+Ua8PufuGprv//t8XWlAzgJERHR8NHfn9+GzhStXbsWJpMJ\nK1as0Lb5/X4sW7YMI0eORGpqKhYvXozTp0/H/LuTJ0+itLQUDocDo0ePxsqVK9HZ2RmzzzvvvIPZ\ns2fDZrNh0qRJ2LhxY4+vv379ekycOBF2ux3z5s3D+++/H3N7X2YhIiIiAgwsivbt24fnn38eF1xw\nQcz2e+65B2+88QZeeeUVVFZWoq6uDtdee612eygUQmlpKYLBIKqqqrBp0yZs3LgRq1ev1vb59NNP\nUVpaissvvxwHDx7EihUrcNttt6GiokLb56WXXkJ5eTkefPBBHDhwABdeeCFKSkrQ0NDQ51lIHX6/\nH5988gn8fn+iR1EC+9bHbsSo0JdsGY3MI1sWUf1aFLW2tuKmm27Cf/3XfyEzM1Pb3tzcjD/84Q94\n4okn8J3vfAdz5szBiy++iKqqKrz77rsAgO3bt+PDDz/En/70JxQUFODKK6/Eww8/jPXr1yMYDAIA\nNmzYgPz8fDz++OM4//zzsXz5clx33XV48sknta/1xBNP4Pbbb0dZWRmmTZuGDRs2wOFw4I9//GOf\nZyF1+P1+1NTUDNlv1KGGfetjN2JU6Eu2jEbmkS2LqH69ovWyZctQWlqKhQsX4j/+4z+07dXV1ejo\n6MDChQu1bVOnTsX48ePhdrtx8cUXw+12Y+bMmcjOztb2KSkpwdKlS1FTU4NZs2bB7XbH3Ed0n+jT\ndMFgENXV1bj//vu125OSkrBw4UK43e4+z3K2QCAQcxmh1+sFAHg8HoTDYdhsNu2lywOBgPY6DBaL\nBU6nE0DXm+FF3x3YbDYjLS0NQNcZspaWFm3W6HOcJkSQ6/xmhlM+k/ZxriMC09efftEGhCJdn2Sn\nRODxeAAAqampSE7uOoytra3a05AOhwNWqxUA0NbWpi047Xa79gdwfr9fe+AORrZIJILm5mYtT0ZG\nhvZxc3M7OrVJAAAgAElEQVQzon/O5nK5kJSUpHUeDocHPFtUR0eH1t1wySbjcYtqa2vTPh4u2Ywe\nt+hcUcMpGzA4xw1ATG/DKVskEtG2t7S0SJEt+mauLS0twtlaW1u1+RP9mOwP4UXRX/7yFxw4cAD7\n9u3rcVt9fT2sVmtMcADIzs5GfX29tk/3BVH09uhtve3j9XrR3t6OpqYmhEKhuPscPXq0z7Ocbe3a\ntVizZk2P7Xv37oXD4cB5552HGTNmaPd/8OBBAMDYsWMxd+5cAEBTU5O2MMvMzMSCBQsAAD6fD5WV\nlQC6DlxJSQkAwGoGVl4Q0r7WT93fHJK7p4dg//rT1dVmNHcdd5RNDmn3NX/+fIwYMQIAcOjQITQ2\nNgIACgsLkZubCwCora3FyZMnAQDTp0/HpEmTAADHjx9HbW0tAAxKts7OTm07AFx11VXax3v27NEe\n4MXFxdo34/79+7VvroHM9i//8i8YP348mpqa8NFHHw2rbDIeN7vdjvHjx+Mf//gHvvrqq2GVbSCO\nW1pamvYf9eGWbaCPm9Vqxbhx43DgwIFhly163KLZDhw4gLy8vIRna2pq0uYRzWaz2TB+/HhYrdaE\nPiaj20QJXX322WefobCwENu3b8eFF14IAPj2t7+NgoICPPXUU9i8eTPKysp6vGjT3LlzccUVV2Dd\nunW44447cOLEiZi/D2pra4PT6cRbb72F733ve5g8eTLKyspizgRt3boVixYtQnt7O86cOYPc3FxU\nVVWhqKhI22flypXYvXs33n333T7NcrZ4Z4ry8vJw4sQJuFyuAf8tYeKqrf0+U2T5+onPhnYgGO7a\nnmWPwGbu2v6VH2gPdW3PtEbgtHRtbw4Chx9eBECN38qZjdmYjdmYTb1sDQ0NyM7OFr76TOhMUXV1\nNRoaGjBnzhxtWygUwq5du/DMM8+goqICwWAQHo8nJnx0OADIycnpcZVY9Iqw7vucfZVYQ0MDXC4X\n7HY7Ro0aBbPZHHef7vdxrlnOZrPZYp5qicrIyOhRqt6+Foulx9kpoOsBFG97BCac8sUdB5+3meJu\nP90ef3ujP/72pqAJTcGe27s/gLobqGwmkynudgBIT0+Pu13vwdv9KZnuHA4HHA5Hj+3M9g1m+waz\nxWK2bzDbN4ZLtv4Q+kPrK664AocPH8bBgwe1/xUWFuKmm27SPrZYLNi5c6f2bz7++GOcPHlSO6NT\nVFSEw4cPx1wltmPHDrhcLkybNk3bp/t9RPeJ3ofVasWcOXNi9gmHw9i5c6e2z5w5c845C6kjGAzi\n888/136joMHFvvWxGzEq9CVbRiPzyJZFlNCiKC0tDTNmzIj5n9PpxMiRIzFjxgykp6djyZIlKC8v\nx9/+9jdUV1fjJz/5CYqKirQ/bC4uLsa0adNw88034//+7/9QUVGBBx54AMuWLdNWpnfeeSeOHTuG\ne++9F0ePHsWzzz6Ll19+Gffcc482S3l5OZ5//nls2rQJH330EZYuXQqfz4eysjIA6NMspI62tjbs\n378/5g9/afCwb33sRowKfcmW0cg8smUR1a+rz3rz5JNPIikpCYsXL0YgEEBJSQmeffZZ7Xaz2Ywt\nW7Zg6dKlKCoqgtPpxI9//GM89NBD2j75+fnYunUrysvL8dvf/hbjxo3DCy+8oP1hGgBcf/31aGxs\nxOrVq1FfX4+CggJs27Yt5qmxc81CREREFMW3+eiFzG/zYYSKbxHS2tqKQ4cO4YILLtB9bpoGDvvW\nx27EqNCXbBmNzCNLlv7+/OaiqBdcFBEREQ09CXnvMyIiIqLhgosiUkJnZyfOnDnT442HaXCwb33s\nRowKfcmW0cg8smURxUURKaG1tRW7d++OeQl6GjzsWx+7EaNCX7JlNDKPbFlEcVFEREREBC6KSBFJ\nSUlIS0vTXkqeBhf71sduxKjQl2wZjcwjWxZRvPqsF7z6jIiIaOjh1WdEREREBnBRREoIh8Nob2/X\n3n2ZBhf71sduxKjQl2wZjcwjWxZRXBSRErxeL7Zv3w6v15voUZTAvvWxGzEq9CVbRiPzyJZFFBdF\nREREROCiiBRhMpmQnJwMk8mU6FGUwL71sRsxKvQlW0Yj88iWRRSvPusFrz4jIiIaenj1GREREZEB\nXBQRERERgYsiUoTH48Hrr78Oj8eT6FGUwL71sRsxKvQlW0Yj88iWRRQXRURERETgooiIiIgIAK8+\n6xWvPhs+IpEIOjs7h/SlokMJ+9bHbsSo0JdsGY3MI0uW/v78Th7EmYikYTKZYLFYEj2GMti3PnYj\nRoW+ZMtoZB7Zsoji02dERERE4KKIFOH1elFRUTFk349nqGHf+tiNGBX6ki2jkXlkyyKKiyJSQjgc\nht/vH7Lv3DzUsG997EaMCn3JltHIPLJlEcVFERERERF49VmvePXZ8BEKheDz+eB0OmE2mxM9zrDH\nvvWxGzEq9CVbRiPzyJKFV58R9cJsNg/KwpbiY9/62I0YFfqSLaOReWTLIopPnxERERGBiyJSREtL\nC3bt2oWWlpZEj6IE9q2P3YhRoS/ZMhqZR7YsorgoIiWEQiE0NTUhFAolehQlsG997EaMCn3JltHI\nPLJlEcVFERERERG4KCJFOJ1OFBUVwel0JnoUJbBvfexGjAp9yZbRyDyyZRHFq89ICRaLBaNHj070\nGMpg3/rYjRgV+pIto5F5ZMsiimeKiIiIiMBFESnC5/Nh37598Pl8iR5FCexbH7sRo0JfsmU0Mo9s\nWURxUURK6OjoQF1dHTo6OhI9ihLYtz52I0aFvmTLaGQe2bKI4qKIiIiICFwUkSJSUlJQUFCAlJSU\nRI+iBPatj92IUaEv2TIamUe2LKJ49RkpwWazYcKECYkeQxnsWx+7EaNCX7JlNDKPbFlE8UwRERER\nEbgoIkW0t7fjyJEjaG9vT/QoSmDf+tiNGBX6ki2jkXlkyyKKiyJSQiAQwLFjxxAIBBI9ihLYtz52\nI0aFvmTLaGQe2bKI4qKIiIiICFwUkSLsdjumTJkCu92e6FGUwL71sRsxKvQlW0Yj88iWRZTQoui5\n557DBRdcAJfLBZfLhaKiIrz11lva7X6/H8uWLcPIkSORmpqKxYsX4/Tp0zH3cfLkSZSWlsLhcGD0\n6NFYuXIlOjs7Y/Z55513MHv2bNhsNkyaNAkbN27sMcv69esxceJE2O12zJs3D++//37M7X2ZhdRh\nt9sxderUIfuNOtSwb33sRowKfcmW0cg8smURJbQoGjduHNatW4f9+/dj//79+M53voOrrroKNTU1\nAIB77rkHb7zxBl555RVUVlairq4O1157rfbvQ6EQSktLEQwGUVVVhU2bNmHjxo1YvXq1ts+nn36K\n0tJSXH755Th48CBWrFiB2267DRUVFdo+L730EsrLy/Hggw/iwIEDuPDCC1FSUoKGhgZtn3PNQkRE\nRNSdKRKJRIzcwYgRI/DYY4/huuuuQ1ZWFjZv3ozrrrsOAHD06FGcf/75cLvduPjii/HWW29h0aJF\nqKurQ3Z2NgBgw4YNuO+++9DY2Air1Yr77rsPW7duxZEjR7SvccMNN8Dj8WDbtm0AgHnz5mHu3Ll4\n5plnAADhcBh5eXm46667sGrVKjQ3N59zlr7wer1IT09Hc3MzXC6XkZrimrhq64DfZ18cX1eakK+b\nSH6/H6dOncK4ceOG7G8wQwn71sduxKjQl2wZjcwjS5b+/vzu94s3hkIhvPLKK/D5fCgqKkJ1dTU6\nOjqwcOFCbZ+pU6di/Pjx2kLE7XZj5syZ2oIIAEpKSrB06VLU1NRg1qxZcLvdMfcR3WfFihUAgGAw\niOrqatx///3a7UlJSVi4cCHcbjcA9GmWeAKBQMxfzHu9XgCAx+NBOByGzWbTXqUzEAholxxaLBY4\nnU4AXe/7En0jPLPZjLS0NK2vlpYWbd7oQTIhglznNzOc8pm0j3MdEZi+/vSLNiAU6fokOyUCy9fn\n+BragWC4a3uWPQKbuWv7V36gPdS1PdMagdPStb05+M3X8vv98Pv9ADAo2SKRCJqbm7Wvl5GRoX3c\n3NyM6Hrc5XIhKSlJ6zwcDgMAUlNTkZzc9RBtbW3VnmZ1OBywWq0AgLa2NgSDXaHsdrv2TXh2tkAg\ngJqaGqSnp2vbh0s2GY+b3+9HTU0NHA4HHA7HsMpm9Li1tLSgpqYGo0aNgt1uH1bZBuO4RR9LNptN\n22+4ZIset8bGRi1jXl5ewrNFH6M2mw0jRowQytba2qo9vm02W0Ifk/0hvCg6fPgwioqK4Pf7kZqa\nildffRXTpk3DwYMHYbVaY0IDQHZ2Nurr6wEA9fX1MQui6O3R23rbx+v1or29HU1NTQiFQnH3OXr0\nqHYf55olnrVr12LNmjU9tu/duxcOhwPnnXceZsyYoX2NgwcPAgDGjh2LuXPnAgCampq0xVlmZiYW\nLFgAoOudgysrKwF0HbiSkhIAgNUMrLwgpH2tn7q/OSR3Tw/B/vWnq6vN2oKmbHIIY7p+zuDJw2Yc\nb+36eHF+GOdndD3IXqxNwsEzXYuiknFhFGV3bX/1+DfPmB4/fhy1tbUAMCjZOjs7te0AcNVVV2kf\n79mzR3uAFxcXa9+M+/fv17655s+fjxEjRgAADh06hMbGRgBAYWEhcnNzAQC1tbU4efIkAGD69OmY\nNGlS3Gzjxo0DAHz55Zf4+OOPh1U2GY9b9D9wn3zyCZqamoZVtoE4bt0Nt2yDcdwA4MCBA8MyW2dn\np5btwIEDMYuiRGX78ssvtXlEs0UXK9FsiXpMRreJEn76LBgM4uTJk/B4PPjrX/+KF154AZWVlTh4\n8CDKysp6vDbB3LlzccUVV2DdunW44447cOLEiZi/D2pra4PT6cRbb72F733ve5g8eTLKyspizgRt\n3boVixYtQnt7O86cOYPc3FxUVVWhqKhI22flypXYvXs33n33XWzevPmcs8QT70xRXl4eTpw4AZfL\nNeC/JUxctTUhZ4oOP7wIgBq/lUezRSIR1NbWIj8/X5thuGST8bgFg0HU1tZi3LhxsFgswyqb0ePm\n9/vx2WefYfr06XA4HMMq22Act7a2Nhw9ehRjx47Vvt5wyRY9bqdPn8aJEycwYcIE5OTkJDybx+NB\nbW0tJkyYgLS0NKFsgUAAdXV1mDJlClJSUhL2mGxoaEB2dvbgP31mtVq1lVhhYSH27duH3/72t7j+\n+usRDAbh8XhigkcHA4CcnJweV4lFrwjrvs/ZV4k1NDTA5XLBbrdj1KhRMJvNcffpfh/nmiUem80G\nm83WY3tGRkaPUvX2tVgsPc5QAV0PoHjbIzDhlC/+PJ+3meJuP90ef3ujP/72pqAJTcGe27s/gLob\nqGwmkynudgBIT0+Pu13vwZuamhp3e/enZ7qLl23WrFlx7wMY+tkAuY5bcnJyr30P5WxRRo5b9x98\nwy1bdwORzeFwYPbs2XHnAYZ2NqDruOXk5MQ8JqISlS0jIwPz5s3rsb2v2br/nE3kY7I/DL9OUTgc\nRiAQwJw5c2CxWLBz507tto8//hgnT57UzugUFRXh8OHDMVeJ7dixAy6XC9OmTdP26X4f0X2i92G1\nWjFnzpyYfcLhMHbu3Knt05dZiIiIiLoTOlP0i1/8AldeeSXy8vLQ0tKCzZs345133kFFRQXS09Ox\nZMkSlJeXY8SIEXC5XLjrrrtQVFSk/WFzcXExpk2bhptvvhmPPvoo6uvr8cADD2DZsmXaivvOO+/E\n7373O9x777249dZb8fbbb+Pll1/G1q3fXKlVXl6OW265BYWFhbjooovw1FNPwefzoaysDAD6NAup\nJRgMorGxEVlZWTHPedPgYN/62I0YFfqSLaOReWTLIkroTNHp06dx8803Y8qUKbjiiiuwb98+VFRU\n4Lvf/S4A4Mknn8SiRYuwePFiLFiwADk5Ofif//kf7d+bzWZs2bIFZrMZRUVF+NGPfoRbbrkFDz30\nkLZPfn4+tm7dih07duDCCy/E448/jhdeeCHmD+6uv/56PP7441i9ejUKCgpw8OBBbNu2LeaU3blm\nIbW0tbVh//79aGtrS/QoSmDf+tiNGBX6ki2jkXlkyyJK6EzRH/7wh15vt9vtWL9+PdavX6+7z4QJ\nE/Dmm2/2ej+XX345Pvjgg173Wb58OZYvX25oFiIiIqIovvcZKSE5ORlZWVnalQw0uNi3PnYjRoW+\nZMtoZB7Zsogy/IrWwxlf0ZqIiGjo6e/Pb54pIiIiIgIXRaSIzs5OnDlzRnvxLxpc7FsfuxGjQl+y\nZTQyj2xZRHFRREpobW3F7t270dramuhRlMC+9bEbMSr0JVtGI/PIlkUUF0VERERE4KKIFJGUlIS0\ntDTt/XVocLFvfexGjAp9yZbRyDyyZRHFq896wavPiIiIhh5efUZERERkABdFpIRwOIz29naEw+FE\nj6IE9q2P3YhRoS/ZMhqZR7YsorgoIiV4vV5s374dXq830aMogX3rYzdiVOhLtoxG5pEtiyguioiI\niIjARREpwmQyITk5GSaTKdGjKIF962M3YlToS7aMRuaRLYsoXn3WC159RkRENPTw6jMiIiIiA7go\nIiIiIgIXRaQIj8eD119/HR6PJ9GjKIF962M3YlToS7aMRuaRLYsoLoqIiIiIwEUREREREQBefdYr\nXn02fEQiEXR2dg7pS0WHEvatj92IUaEv2TIamUeWLP39+Z08iDMRScNkMsFisSR6DGWwb33sRowK\nfcmW0cg8smURxafPiIiIiMBFESnC6/WioqJiyL4fz1DDvvWxGzEq9CVbRiPzyJZFFBdFpIRwOAy/\n3z9k37l5qGHf+tiNGBX6ki2jkXlkyyKKiyIiIiIi8OqzXvHqs+EjFArB5/PB6XTCbDYnepxhj33r\nYzdiVOhLtoxG5pElC68+I+qF2WwelIUtxce+9bEbMSr0JVtGI/PIlkUUnz4jIiIiAhdFpIiWlhbs\n2rULLS0tiR5FCexbH7sRo0JfsmU0Mo9sWURxUURKCIVCaGpqQigUSvQoSmDf+tiNGBX6ki2jkXlk\nyyKKiyIiIiIicFFEinA6nSgqKoLT6Uz0KEpg3/rYjRgV+pIto5F5ZMsiilefkRIsFgtGjx6d6DGU\nwb71sRsxKvQlW0Yj88iWRRTPFBERERGBiyJShM/nw759++Dz+RI9ihLYtz52I0aFvmTLaGQe2bKI\n4qKIlNDR0YG6ujp0dHQkehQlsG997EaMCn3JltHIPLJlEcVFERERERG4KCJFpKSkoKCgACkpKYke\nRQnsWx+7EaNCX7JlNDKPbFlE8eozUoLNZsOECRMSPYYy2Lc+diNGhb5ky2hkHtmyiOKZIiIiIiJw\nUUSKaG9vx5EjR9De3p7oUZTAvvWxGzEq9CVbRiPzyJZFFBdFpIRAIIBjx44hEAgkehQlsG997EaM\nCn3JltHIPLJlEcVFEREREREEF0Vr167F3LlzkZaWhtGjR+Pqq69GbW1tzD5+vx/Lli3DyJEjkZqa\nisWLF+P06dMx+5w8eRKlpaVwOBwYPXo0Vq5cic7Ozph93nnnHcyePRs2mw2TJk3Cxo0be8yzfv16\nTJw4EXa7HfPmzcP7778vPAupwW63Y8qUKbDb7YkeRQnsWx+7EaNCX7JlNDKPbFlECS2KKisrsWzZ\nMrz77rvYsWMHOjo6UFxcHPPKlffccw/eeOMNvPLKK6isrERdXR2uvfZa7fZQKITS0lIEg0FUVVVh\n06ZN2LhxI1avXq3t8+mnn6K0tBSXX345Dh48iBUrVuC2225DRUWFts9LL72E8vJyPPjggzhw4AAu\nvPBClJSUoKGhoc+zkDrsdjumTp06ZL9Rhxr2rY/diFGhL9kyGplHtiyiTJFIJNLff9zY2IjRo0ej\nsrISCxYsQHNzM7KysrB582Zcd911AICjR4/i/PPPh9vtxsUXX4y33noLixYtQl1dHbKzswEAGzZs\nwH333YfGxkZYrVbcd9992Lp1K44cOaJ9rRtuuAEejwfbtm0DAMybNw9z587FM888AwAIh8PIy8vD\nXXfdhVWrVvVplrMFAoGY50G9Xi/y8vJw4sQJuFwu2Gw27bUXAoGA9odkFotFe0fgjo4ObZFoNpuR\nlpYGoGsx2NLSAgBISkqCy+XCxFVbYUIEud3eTPiUz6R9nOuIwPT1p1+0AaFI1yfZKRFYvl7ONrQD\nwXDX9ix7BDZz1/av/EB7qGt7pjUCp6Vre3MQOPzwIgBdZ9L8fj8A9Dnb5eu6FqbBENDg77p/S1IE\n2V+/JEUoAnzR1rX97Gx7frVI+7i5uRnRh57L5UJSUpLWeTgcBgCkpqYiObnrVSNaW1u1s4kOhwNW\nqxUA0NbWhmAwCKDrmzH6jdifbH09bgAQiUTQ3Nys5cnIyGA2ZmM2ZmM2SbI1NDQgOzsbzc3N2jx9\nYeh1iqJhR4wYAQCorq5GR0cHFi5cqO0zdepUjB8/XluIuN1uzJw5U1sQAUBJSQmWLl2KmpoazJo1\nC263O+Y+ovusWLECABAMBlFdXY37779fuz0pKQkLFy6E2+3u8yxnW7t2LdasWdNj+969e+FwOHDe\needhxowZAID6+nocPHgQADB27FjMnTsXANDU1KTNkJmZiQULFgDoej+YyspKAF0HrqSkBABgNQMr\nLwhpX+un7m8Oyd3TQ7B//enqajOau447yiaHMMbR9fGTh8043tr18eL8MM7P6HqQvVibhINnuhYn\nJePCKMru2v7q8W9ODh4/flx7+rOv2aKzftoCPHWka7iRtm8yeALAgweS42brbs+ePdoDvLi4WPtm\n3L9/v/bNNX/+fO2xdejQITQ2NgIACgsLkZubCwCora3FyZMnAQDTp0/HpEmT4mabNGkSTp06BQCo\nqamJm03kuHV2dmrbAeCqq65KWLaBfkwORDaHw4FTp06hvr4eX3311bDKNhDHbeTIkSgsLITdbh92\n2Qb6uPn9fpw4cQJHjx4ddtlkPW6fffZZv/87Gf2Tl3HjxsFsNicsW3SbqH6fKQqHw/i3f/s3eDwe\n7NmzBwCwefNmlJWV9fir84suugiXX345HnnkEdxxxx04ceJEzFNhbW1tcDqdePPNN3HllVdi8uTJ\nKCsri1n0vPnmmygtLUVbWxuampqQm5uLqqoqFBUVafvce++9qKysxHvvvdenWc7GM0XD90xRIBBA\nZWUlLrnkElgsFkPHDeBvd+fK1traisrKSsydOxcOh2NYZTN63FpaWnDgwAFcdtllyMjIGFbZBuO4\neTweVFZWYvbs2dp+wyVb9LidOnUKBw4cwOzZs5GXl5fwbI2NjaiqqsLs2bMxYsQIoWytra2orq7G\nZZddhvT0dHXOFC1btgxHjhzRFkS9iUQiMJlM59yvt32i5Z1rn3N9nd72sdlssNlsPbZnZGT0KFVv\nX4vFEnPgo8xmc9ztEZhwSufNhD9viz/n6fb42xv98bc3BU1oCvbc3v0B1F1v2bov2qI6wvEz9JYt\nPT097na9B29qamrc7Q6HQ/uh293Z2aKLXb3jI3rcTCZT3O3APz9b1EA9Jgcym8PhiHtfwyHbcD5u\nsmUDgLS0tLi3DfVsJpNJW1xE/z8qUdmivzimpaVpC6Lo9qH0mOyPfl2Sv3z5cmzZsgV/+9vfMG7c\nOG17Tk4OgsEgPB5PzP7RFVt0n7OvAIt+3ts+DQ0NcLlcsNvtGDVqFMxmc9x9ut/HuWYhdVitVowf\nP1777YIGF/vWx27EqNCXbBmNzCNbFlFCi6JIJILly5fj1Vdfxdtvv438/PyY2+fMmQOLxYKdO3dq\n2z7++GOcPHlSe5qrqKgIhw8fjrlKbMeOHXC5XJg2bZq2T/f7iO4TvQ+r1Yo5c+bE7BMOh7Fz505t\nn77MQupwOByYNWtW3N8oaOCxb33sRowKfcmW0cg8smURJfT02bJly7B582a8/vrrSEtLQ319PYCu\n02ApKSlIT0/HkiVLUF5ejhEjRsDlcuGuu+5CUVGR9ofNxcXFmDZtGm6++WY8+uijqK+vxwMPPIBl\ny5ZppyLvvPNO/O53v8O9996LW2+9FW+//TZefvllbN26VZulvLwct9xyCwoLC3HRRRfhqaeegs/n\nQ1lZmTbTuWYhIiIiihJaFD333HMAgG9/+9sx21988UX85Cc/AQA8+eSTSEpKwuLFixEIBFBSUoJn\nn31W29dsNmPLli1YunQpioqK4HQ68eMf/xgPPfSQtk9+fj62bt2K8vJy/Pa3v8W4cePwwgsvaH+t\nDwDXX389GhsbsXr1atTX16OgoADbtm2LeWrsXLOQOoLBIBobG5GVlTVkT+sOJexbH7sRo0JfsmU0\nMo9sWUQZep2i4c7r9Wp/PS/y1+t9NXHV1nPvNAiOryvt9781MrORr2tU9AqW6BU/NLjYtz52I0aF\nvmTLaGQeWbL09+c33/uMiIiICFwUkSKSk5ORlZWlveYFDS72rY/diFGhL9kyGplHtiyi+PRZL/j0\nWU9D9ekzIiJSB58+IyIiIjKAiyJSQmdnJ86cOaO9TDwNLvatj92IUaEv2TIamUe2LKK4KCIltLa2\nYvfu3WhtbU30KEpg3/rYjRgV+pIto5F5ZMsiiosiIiIiInBRRIpISkpCWlqa9k7MNLjYtz52I0aF\nvmTLaGQe2bKI4tVnveDVZz3x6jMiIpIdrz4jIiIiMoCLIlJCOBxGe3s7wuFwokdRAvvWx27EqNCX\nbBmNzCNbFlFcFJESvF4vtm/fDq/Xm+hRlMC+9bEbMSr0JVtGI/PIlkUUF0VERERE4KKIFGEymZCc\nnAyTyZToUZTAvvWxGzEq9CVbRiPzyJZFFK8+6wWvPuuJV58REZHsePUZERERkQFcFBERERGBiyJS\nhMfjweuvvw6Px5PoUZTAvvWxGzEq9CVbRiPzyJZFFBdFREREROCiiIiIiAgArz7rFa8+62moXn0W\niUTQ2dk5pC8VHUrYtz52I0aFvmTLaGQeWbL09+d38iDORCQNk8kEi8WS6DGUwb71sRsxKvQlW0Yj\n8/5/WS4AABxgSURBVMiWRRSfPiMiIiICF0WkCK/Xi4qKiiH7fjxDDfvWx27EqNCXbBmNzCNbFlFc\nFJESwuEw/H7/kH3n5qGGfetjN2JU6Eu2jEbmkS2LKC6KiIiIiMCrz3rFq896GqpXn4VCIfh8Pjid\nTpjN5oTNoQr2rY/diFGhL9kyGplHliy8+oyoF2azeVAWthQf+9bHbsSo0JdsGY3MI1sWUXz6jIiI\niAhcFJEiWlpasGvXLrS0tCR6FCWwb33sRowKfcmW0cg8smURxUURKSEUCqGpqQmhUCjRoyiBfetj\nN2JU6Eu2jEbmkS2LKC6KiIiIiMBFESnC6XSiqKgITqcz0aMogX3rYzdiVOhLtoxG5pEtiyhefUZK\nsFgsGD16dKLHUAb71sduxKjQl2wZjcwjWxZRPFNEREREBC6KSBE+nw/79u2Dz+dL9ChKYN/62I0Y\nFfqSLaOReWTLIoqLIlJCR0cH6urq0NHRkehRlMC+9bEbMSr0JVtGI/PIlkUUF0VERERE4KKIFJGS\nkoKCggKkpKQkehQlsG997EaMCn3JltHIPLJlEcWrz0gJNpsNEyZMSPQYymDf+tiNGBX6ki2jkXlk\nyyKKZ4qIiIiIwEURKaK9vR1HjhxBe3t7okdRAvvWx27EqNCXbBmNzCNbFlHCi6Jdu3bhBz/4AcaO\nHQuTyYTXXnst5vZIJILVq1djzJgxSElJwcKFC/H3v/89Zp8zZ87gpptugsvlQkZGBpYsWYLW1taY\nfQ4dOoT58+fDbrcjLy8Pjz76aI9ZXnnlFUydOhV2ux0zZ87Em2++KTwLqSEQCODYsWMIBAKJHkUJ\n7FsfuxGjQl+yZTQyj2xZRAkvinw+Hy688EI888wzcW9/9NFH8fTTT+O5557De++9B6fTiZKSEvj9\nfm2fm266CTU1NdixYwe2bNmCXbt24Y477tBu93q9KC4uxoQJE1BdXY3HHnsMv/71r/H8889r+7jd\nbtx4441YsmQJPvjgA1xzzTW4+uqrceTIEaFZiIiIiADAFIlEIv3+xyYTXn31VVx99dUAus7MjB07\nFj/72c/w85//HADQ3NyM7OxsbNy4ETfccAM++ugjTJs2Dfv27UNhYSEAYNu2bfj+97+PU6dOYezY\nsXjuuefwy1/+EvX19bBarQCAVatW4bXXXsPRo0cBANdffz18Ph+2bNmizXPxxRejoKAAGzZs6NMs\n5+L1epGeno7m5ma4XK7+1qRr4qqtA36ffXF8XWm//62RmY18XaP8fj+OHz+OiRMnwm63J2wOVbBv\nfexGjAp9yZbRyDyyZOnvz+8Bvfrs008/RX19PRYuXKhtS09Px7x58+B2u3HDDTfA7XYjIyNDWxAB\nwMKFC5GUlIT33nsP11xzDdxuNxYsWKAtiACgpKQEjzzyCJqampCZmQm3243y8vKYr19SUqI9ndeX\nWc4WCARiTvl5vV4AgMfjQTgchs1m0y4zDAQC2nOmFotFe/O7jo4O7ZU8zWYz0tLSAAChUAgtLS0A\ngKSkJO0gmRBBbrf3zTvlM2kf5zoiMH396RdtQCjS9Ul2SgSWr8/xNbQDwXDX9ix7BDZz1/av/EB7\nqGt7pjUCp6Vre3Pwm6/l9/u1s2Z9zTbO2bWGDoaABn/X/VuSIsj++urLUAT4os0UN1t3zc3NiK7H\nXS4XkpKStM7D4TAAIDU1FcnJXQ/R1tZWdHZ2AgAcDof22Ghra0Mw2BXKbrdr34Txsk2dOhWBQAAe\njyduNpHjFolE0NzcrOXJyMhIaLZzHbd/dja73Y6pU6eitbVV63u4ZBuI4zZhwgRt+3DLNtDHzW63\nY8qUKWhubta+xnDJFj1ufr8fOTk58Pv9MQuJRGUzmUzaPKFQSDjb1KlTtWyJfEz2x4Auiurr6wEA\n2dnZMduzs7O12+rr63u8WVxycjJGjBgRs09+fn6P+4jelpmZifr6+nN+nXPNcra1a9dizZo1Pbbv\n3bsXDocD5513HmbMmKHd/8GDBwEAY8eOxdy5cwEATU1NcLvdAIDMzEwsWLAAQNfTjpWVlQC6DlxJ\nSQkAwGoGVl4Q0r7WT93fHJK7p4dg//rT1dVmbUFTNjmEMY6uj588bMbxr/8ca3F+GOdndD3IXqxN\nwsEzXYuTknFhFGV3bX/1+DfPmB4/fhy1tbUA0Ods0Vk/bQGeOtI13EjbNxk8AeDBA8lxs3W3Z88e\n7QFeXFysfTPu379f++aaP38+RowYAaDrb8waGxsBAIWFhcjNzQUA1NbW4uTJkwCA6dOnY9KkSf3O\nJnLcOjs7te0AcNVVVzEbszEbszGbJNmi20QN6NNnVVVVuPTSS1FXV4cxY8Zo+/3whz+E2WzGX/7y\nF/zmN7/Bpk2btAMRlZWVhYcffhh33nkniouLkZ+fj9///vfa7TU1NZgxYwY++ugjTJ06FVarFZs2\nbcKNN96o7bN+/Xo8/PDDqK+v79MsZ4t3pigvLw8nTpyAy+Ua8N8SJq7ampAzRYcfXgSgf78BXb6u\nAkD/zhQZyXbkgcsM/QZkMplw6tQpjB49WvsthL+VD162zs5OnDp1CpmZmTCbzcMqm9HjFgwG8dVX\nXyE/Px92u31YZRuM4+b3+/HZZ58hPT1dm2O4ZIset8bGRpw+fRrZ2dkxJw0Slc3r9eLEiRPIzs6G\n0+kUytbR0YHm5maMGzcONpstYY/JhoYGZGdnJ/bps5ycHADA6dOnYxYiDQ0NKCgo0PZpaGiI+Xed\nnZ1oamrSzurk5OTg9OnTMftE/8259ul++7lmOZvNZoPNZuuxPSMjo0epevtaLJaYAx9lNpvjbo/A\nhFM675v3eZsp7vbT7fG3N/rjb28KmtDU7WkzY3/L1PNrdITjZxjIbKmpqXG3OxwOOByOHtu7f3MA\nXU+B1tTUYNSoUXGPg+hxM5lMcbcDXU/TxqP3jWk0W9RAPSYHIltraytqampw2WWXxb2voZwtqr/H\nzePx4OOPP8aYMWNgt9uHVbazDUQ2v9+PDz/8UPexNJSzAV3HzWq14h//+Afy8vJibktUtnA4rM0T\nXRABfcvW/b+1drs9oY/J/hjQ1ynKz89HTk4Odu7cqW3zer147733UFRUBAAo+v/t3X1QVPW/B/D3\nsrDLM6jEk7pIjqiU4i2VHHNGRhsfEMcyHzIFMZyuijd/VlPNSOLV5k6aaWpqNgrT+NM0ZswstRyz\nMYmrqGBOKqOmV0oEzdblQRbY/d4/VlcJFjgsu+fsnvdrxkG+nN3z+XzOnrOfPU87YgSMRiPOnDlj\nn+bHH3+E1WpFcnKyfZrjx483+0K5I0eOoH///ujWrZt9msfn83Cah/PpSCxERERED0luimpqalBa\nWmo/3njt2jWUlpbixo0b0Gg0WLJkCVatWoVvvvkG58+fR3p6OmJjY+2H2AYOHIjx48dj/vz5OHXq\nFAoLC5GdnY2ZM2ciNjYWADBr1izodDq89tpr+O2337Bnzx588sknzU6sfuONN3Do0CGsXbsWly5d\nQm5uLk6fPo3s7GwA6FAspB46nQ4Gg6HZyfvkOqy3Y6yNNGqol9JydCYepeUileRzin766SekpKS0\nGM/IyEB+fj6EEFi+fDm2bdsGo9GI559/Hps3b0ZCQoJ92rt37yI7OxsHDhyAj48Ppk6dig0bNjTb\nPXbu3DlkZ2ejuLgYERERWLx4Md55551m8/zqq6+wbNkyXL9+Hf369cPq1asxceJE+987EktbvPWS\nfE8k5+X8RETkWTr7/u3Uidbejk2RcrApIiKijurs+ze/+4xUoaGhAX/++af9KgVyLdbbMdZGGjXU\nS2k5OhOP0nKRik0RqUJdXR1Onz6Nuro6uUNRBdbbMdZGGjXUS2k5OhOP0nKRqksvySciIiLP9PCU\njl5BAm8PBiZtPNHs/nJt8ZZTHLiniFTB19cXTzzxhP1GYORarLdjrI00aqiX0nI0W4CLRg3MrX8h\nQZuUlotUPNG6DTzRWjm85VMIEZFSeeoXfreGJ1oTEREROYFNEalCU1MT7t69a//uHHIt1tsx1kYa\nNdRLaTnqfAT6BAvofKQfSFJaLlKxKSJVqKmpwc8//4yamhq5Q1EF1tsx1kYaNdRLaTlGBgD/GmRB\nZID0xyotF6nYFBERERGBl+STSvj4+CAkJAQ+Pvwc4A6st2OsjTRqqJfScmy0AhV1tp8d9fAk7agA\ngcwEYNwnJ1B53/Mu5+fVZ23g1WfKoaSVhoioPZ54JZdc70muyJdXnxERERE5gYfPSBWsVivMZjP0\ner1idlF7M9bbMdZGGjXUS6sRCPYDahoBi+jYISdHumJvjzPxdGUucvDOVxjRP5hMJvzwww8wmUxy\nh6IKrLdjrI00aqhXTCDw389aEBModyQ2zsSjtFyk4p4i8gieeHyeiIg8C5si8np93v0OPQMF/usp\nIHXDCfxZ1/FdumyoOkej0cDX1xcajeftPnc11kYaNdRLCKC+yfZTCZyJR2m5SMWmiFThzzoN3inm\ny91dwsLCkJrKhrI1rI00aqiX0rZPzsSjtFyk4jlFRERERGBTRERERASATRGpRK8ggU9GNKFXkIce\n6PYwRqMR+/fvh9FolDsUxWFtpFFDvZS2fXImHqXlIpXnHvgjIiLyQvy2A/mwKSJqA28FQESkHvzu\nszbwu8+8hwYCOi3QYAEE3HNpr5qbIiEEmpqavP5S6s5gbaTx1HpJ2b7LsX1yVTydeaySvvuMe4pI\nFQQ0MFvkjkI9NBoN/Pz85A5DkVgbadRQL6Vtn5yJR2m5SMUTrYmIiIjApohUIiZQYMUzTYgJ5NFi\ndzCZTPj++++9+vuqOou1kUYN9VLa9smZeJSWi1RsikgVtBogXG/7Sa5ntVpRX18Pq9UqdyiKw9pI\no4Z6KW375Ew8SstFKjZFREREROCJ1qQSlfeB/ynV4i+z3JGoQ0hICFJSUhAUFCR3KIrD2kijhnop\nbfvkTDxKy0UqNkWkCo1WDW7dd+881XyPI61W65LbWHgD1kYaNdRLju1TW5yJR2m5SMXDZ0RERERg\nU0QqEekvsOTpJkT6e+YVEZ6muroax48fR3V1tdyhKA5rI40a6qW07ZMz8SgtF6nYFJEq6LRAfIjt\nJ7mexWLB33//DYvFg+/i5iKsjTRqqJfStk/OxKO0XKRiU0REREQENkWkErfrgS0XfHC7Xu5I1CEo\nKAgjRozw6iuGOou1kUYN9VLa9smZeJSWi1S8+oxUwWzR4NI9z7mbmKdfuebn54fIyEi5w1Ak1kYa\nNdRLadsnZ+JRWi5ScU8REREREbiniFSih14gLc6KA//ng7/MnvspxlPU1tbiwoULSExM9OrDHp3B\n2kjjbL2c2evqLkrbPjkTj9JykYp7ikgVAnyB/+ghEMCPAW7R2NiImzdvorGxUe5QFIe1kUYN9VLa\n9smZeJSWi1QeGjYROeLp5yMREcmFe4pIFf42A7uv+uBvD/0+Hk8TEBCAIUOGICAgQO5QFIe1kUYN\n9VLa9smZeJSWi1TcU0SqUNukwf9Wed7xbU+l1+sRFxcndxiKxNpIo4Z6KW375Ew8SstFKjZFRGTH\nQ2/kiCecsEzkLFU0RZ9++inWrFmDW7duISkpCRs3bsTw4cPlDovcKEwnkBJjxbEKH9xr8NxPMUr2\n+Jum1Hp7YkPV2SYhTCfw7+l90LdvX68+JNRV1LDuKi1HZ+JRWi5SeX1TtGfPHixduhRbt25FcnIy\n1q9fj3HjxqGsrMzrbwhGj4T4ASmxAqfvAPca5I7G+7HejoX4AVevXsV/7ruOP2o9703D3dTwWlJa\njs7Eo7RcpPL6pujjjz/G/PnzkZmZCQDYunUrvvvuO+zYsQPvvvtus2nNZjPM5kdnh927dw8AUF5e\njpCQEOj1evsnO7PZjPv37wOw3XH14f0zGhsbUVtbCwDQarUICQkBYPtSw4ff8uzj44PQ0FBYzXXQ\nQCAm8FEMN+sebSRjAgQ0D36tvA9YhO2XSH8B3wenyN+uBxqttvEIfwHdg/G7ZqDeYhsP1wkEPljS\npkagptE2HuInEOJnG69pAkwPuvpAX4FwnW283gLcfXCvCZ1WIEJvG2+0ArfrbeN+PgJP+NvGLQKo\nvG8bV1JuTfVAXZ0Ffo0+iNZqvCo3JS63h/UOsj6qd1u5Gf71lcfk5uxy66YRqKuzoqleC6tZ41W5\nAV2/3Jq0AnV1FnTT+KDpwWvJW3IDbMutW7DtNdFN44Mb5kfXP8mVm5/Oao+nBhpJuYXh0etbmNGh\n16TRaISPjy1wk8kEq9UKAAgODoavry3wmpoaNDU12WofGAidzlb8uro6NDTYui9/f3/4+9sCuX37\nNgBACAEpNELqIzxIQ0MDAgMDUVBQgClTptjHMzIyYDQasX///mbT5+bmYsWKFe4Ok4iIiFygvLwc\nvXr16vD0Xr2n6M6dO7BYLIiKimo2HhUVhUuXLrWY/r333sPSpUvtv1utVty9exc9evTA8OHDUVxc\n3Ob8hg0b5nCatv5GztenvcebTCb07t0b5eXlCA0N7dJ5q4HUGj1e7zFjxnDdeUxbr8XOcPW609Y0\n7lg2XV0vd+pofRzlKNeycabmSlleQghUV1cjNjZW0uO8uilyRAgBjUbTYlyv10Ov1zcbCw8PB2A7\nFNbeAm5rmo48Xs2crU9HHx8aGtpiOi6b9nW2RqGhoVx3HGjttdgZ7lh3HE3jzmXTVfVyJ6n1+WeO\nci8bZ2quhOUVFhYm+TFeffPGiIgIaLVaVFZWNhuvqqpqsfeoPYsWLXJqmo48Xs2crY8zj+eyaZ+r\n68t1p/Pcse44mobLpm1cNp7Hq88pAoDk5GQMHz4cGzduBGA7JGYwGJCdnd3iRGvyXiaTCWFhYbh3\n757sn17UgPV2jLWRRg31UlqOzsSjtFyk0ubm5ubKHYQrhYaGYtmyZTAYDNDr9cjJyUFpaSm2b9+O\n4OBgucMjN9JqtRg9erT9agZyLdbbMdZGGjXUS2k5OhOP0nKRwuv3FAHApk2b7DdvHDJkCDZs2IDk\n5GS5wyIiIiIFUUVTRERERNQerz7RmoiIiKij2BQRERERgU0REREREQA2RUTkIn369MH69evlDsOj\nsGZE8mJTRB7v+PHjSEtLQ2xsLDQaDb7++mu5Q1IF1r1trE/r1FwXJeWem5sLjUbT7N+AAQMcTt9e\n7EIIvP/++4iJiUFAQADGjh2Ly5cvuzqNLsemiDxebW0tkpKSsGnTJrlDURXWvW2sT+vUXBel5f7U\nU0+hoqLC/u/EiRMOp20v9tWrV2PDhg3YsmULTp48iaCgIIwbNw719fWuCt81BJEXASD27dvXbCwu\nLk6sXLlSzJkzRwQFBQmDwSD2798vqqqqxOTJk0VQUJAYNGiQKC4ulilqz+eo7h988IHIzMwUwcHB\nonfv3uKzzz6TKUJ5tVafyspKMWnSJOHv7y/69Okjdu7cKeLi4sS6detkitL9unJ9LSgoEImJiUKn\n04m4uDjx0UcfuTMVyf6Z+4oVK8TTTz/dYrqkpCSRk5PT5fNfvny5SEpKavVvmZmZIjU1tdlYQ0OD\niIiIENu3b28Ru9VqFdHR0WLNmjX2MaPRKPR6vdi9e7cQQoiUlBSxaNGiZs9ZVVUl/Pz8xNGjR7sq\nLadxTxGpwrp16zBy5EiUlJQgNTUVc+bMQXp6OmbPno2zZ8+ib9++SE9Ph+Btu7rU2rVrMXToUJSU\nlGDhwoVYsGABLl26JHdYijB37lyUl5fj2LFjKCgowObNm1FVVSV3WIogdX09c+YMpk+fjpkzZ+L8\n+fPIzc1FTk4O8vPz5U1Egnnz5uHChQvNvtm+pKQEv/76K+bOneuSeV6+fBmxsbF48skn8eqrr+LG\njRsAgKysLBw+fBgVFRX2ab/99lvcv38f06dPb/E8165dw61btzB27Fj7WFhYGJKTk1FUVGR/zl27\ndsFsNtun2blzJ3r27ImUlBSX5NcpcndlRF0JDj55zp492/57RUWFANDs01dRUZEAICoqKtwWqzfp\nSN2tVquIjIwUW7ZscXd4svtnfcrKygQAcerUKfvYxYsXBQDuKerE+jpr1izxwgsvNHuet99+WyQm\nJroweue0lvuECRPEggUL7L8vXrxYjB492iXzP3jwoNi7d684d+6cOHz4sBgxYoQwGAzCZDIJIYRI\nTEwUH374oX36tLQ0MXfu3FZjLywsFADEzZs3m81j2rRpYvr06UIIIerr60X37t3Fnj177H8fPHiw\nyM3NdUl+ncU9RaQKgwcPtv8/KioKADBo0KAWY/yk3rUer7tGo0F0dDRrDODixYvw9fXFs88+ax8b\nMGAAwsPDZYxKOaSurxcvXsTIkSObPcfIkSNx+fJlWCwWV4fbZebPn4/du3ejvr4eDQ0N2LVrF+bN\nm+eSeU2YMAHTpk3D4MGDMW7cOBw8eBBGoxF79+4FYNuzk5eXBwCorKzEoUOHJMcihIBGowEA6PV6\nzJ49Gzt27AAAnD17FufPn3fZXrDOYlNEquDn52f//8OVtLUxq9Xq3sC83OM1Bmx1Zo3Bw7TtkLq+\nPv7m+5An1jgtLQ16vR779u3DgQMH0NjYiKlTp7pl3uHh4UhISMCVK1cAAOnp6fj9999RVFSEnTt3\nIj4+HqNGjWr1sdHR0QBszdPjqqqq7A0sYGu0jhw5gj/++AN5eXkYM2YM4uLiXJRR57ApIiJys4ED\nB6KpqQlnzpyxj5WVlcFoNMoYledKTExsceXUL7/8goSEBGi1Wpmiks7X1xcZGRnIy8tDXl4eZs6c\nicDAQLfMu6amBlevXkVMTAwAoEePHpgyZQry8vKQn5+PzMxMh4+Nj49HdHQ0jh49ah8zmUw4efIk\nRowYYR8bNGgQhg4dis8//9yle8Gc4St3AETOqqmpsX+6AWwn/ZWWlqJ79+4wGAwyRubdWPe2tVWf\n/v37Y/z48Xj99dexZcsW+Pr6YsmSJQgICJAxYvdwxevmzTffxLBhw7By5UrMmDEDRUVF2LRpEzZv\n3txVYXeJjuSelZWFgQMHAgAKCwtdFstbb72FtLQ0xMXF4ebNm1i+fDm0Wi1eeeUV+zRZWVmYNGkS\nLBYLXn75ZZSWljqMfcmSJVi1ahX69euH+Ph45OTkIDY2FlOmTGk236ysLGRnZyMwMBAvvviiy/Lr\nNHlPaSJy3rFjxwSAFv8yMjKEEKLVy5zxjxMFr127JgCIkpISd4bu0TpT96SkJLF8+XL3ByuD9upT\nUVEhUlNThV6vFwaDQXzxxRequCTfVevrw0vy/fz8hMFgaHZ5uFK0l/tDo0aNcvlJ4jNmzBAxMTFC\np9OJnj17ihkzZogrV640m8ZqtYq4uDgxceLEdmO3Wq0iJydHREVFCb1eL8aMGSPKyspazLe6uloE\nBgaKhQsXujS/ztII4YEHXomIiLyQEAL9+vXDwoULsXTpUlljqa2tRWxsLPLy8vDSSy91yXNev34d\nffv2RXFxMZ555pkuec6uxMNnRERECnD79m18+eWXuHXrVpvn8Lia1WrFnTt3sHbtWoSHh2Py5MlO\nP2djYyP++usvLFu2DM8995wiGyKATREREZEiREZGIiIiAtu2bUO3bt1ki+PGjRuIj49Hr169kJ+f\nD19f51uFwsJCpKSkICEhAQUFBV0QpWvw8BkREREReEk+EREREQA2RUREREQA2BQRERERAWBTRERE\nRASATRERERERADZFRERERADYFBEREREBYFNEREREBAD4f2R0eWFfgw8qAAAAAElFTkSuQmCC\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fdf89921748>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.style.use('default')\n",
+    "\n",
+    "def plot_loghist(x, bins):\n",
+    "    hist, bins = np.histogram(x, bins=bins)\n",
+    "    logbins = np.logspace(np.log10(bins[0]),np.log10(bins[-1]),len(bins))\n",
+    "    plt.hist(x, bins=logbins)\n",
+    "    plt.xscale('log')\n",
+    "    plt.xticks([60, 60*60, 24*60*60, 30*24*60*60, 365*24*60*60, 5*365*24*60*60, 10*365*24*60*60],\n",
+    "      [\"1m\", \"1h\", \"1d\", \"1mo\", \"1y\", \"5y\", \"10y\"])\n",
+    "    axes = plt.axes()\n",
+    "    axes.grid(linestyle=':', linewidth=1)\n",
+    "\n",
+    "\n",
+    "plot_loghist(time_to_sdc.loc[time_to_sdc['time_to_edit'] > 0]['time_to_edit'], 30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "The vertical lines in the histogram are 1 minute, 1 hour, 1 day, 1 month, 1 year, 5 years, and 10 years, by the way.\n",
+    "\n",
+    "## Time to edit for non-SDC data\n",
+    "\n",
+    "Here we look at time since an article was created for an edit that is not a structured edit, that added something to the file. The edit cannot be a revert, because that would mean it's reinstating a previous state of the file, nor should it have been reverted within 48 hours, as that would mean it's likely an unproductive edit."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 13,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "## Time between page creation and edit \n",
+    "\n",
+    "time_to_data_query = '''\n",
+    "SELECT unix_timestamp(event_timestamp) - unix_timestamp(page_creation_timestamp) AS time_to_edit\n",
+    "FROM commons_edits\n",
+    "WHERE event_comment NOT REGEXP \"^...wbsetclaim-create:.*?Special:EntityPage/(P\\\\\\\\d+)\"\n",
+    "AND event_comment NOT REGEXP \"^...wbsetlabel-add:\"\n",
+    "AND revision_text_bytes_diff > 0\n",
+    "AND (revision_is_identity_reverted = false\n",
+    "     OR revision_seconds_to_identity_revert > 48 * 60 * 60)\n",
+    "AND revision_is_identity_revert = false\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "time_to_data = spark.sql(time_to_data_query).toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>time_to_edit</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>66.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>338449.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>5</th>\n",
+       "      <td>193966.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>6</th>\n",
+       "      <td>2651063.0</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>8</th>\n",
+       "      <td>1564.0</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   time_to_edit\n",
+       "0          66.0\n",
+       "4      338449.0\n",
+       "5      193966.0\n",
+       "6     2651063.0\n",
+       "8        1564.0"
+      ]
+     },
+     "execution_count": 15,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "time_to_data.loc[time_to_data['time_to_edit'] > 0].head()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAk4AAAGgCAYAAABc/+iaAAAABHNCSVQICAgIfAhkiAAAAAlwSFlz\nAAAPYQAAD2EBqD+naQAAIABJREFUeJzs3Xt0FGWa+PFvdacvuV+QhAQCZEABgRG5TAwKysomOqwr\nDOMO6K6XZYaVn3EG2VUcx2G5eLzgbxx0dGA8+3Ngz3hbzxlxBxVkUUGhhyEog0GIl+EyGkJYSKeT\nTrrTl/r90d0FTUKT6iR2pXg+53CSvPVW532eqqafVNVbpaiqqiKEEEIIIS7IkuoBCCGEEEL0F1I4\nCSGEEEJ0kxROQgghhBDdJIWTEEIIIUQ3SeEkhBBCCNFNUjgJIYQQQnSTFE5CCCGEEN0khZMQQggh\nRDdJ4SSEEEII0U1SOAkhhBBCdJMUTkIIIYQQ3ZSW6gH0d+FwmPr6erKzs1EUJdXDEUIIIUQ3qKpK\nS0sLJSUlWCzdP44khVMP1dfXU1pamuphCCGEECIJf/3rXxkyZEi3+0vh1EPZ2dlAJPE5OTkpHo3o\nCbfbzc6dO7n66qvJy8tL9XBMTXKdmORHH7Pny2jx9XQ8RonH4/FQWlqqfY53lxROPRQ7PZeTkyOF\nkwkUFRWRl5cn2/IbILlOTPKjj9nzZbT4ejoeI8Wj9zIbRVVVtY/GclHweDzk5ubS3NxsiB1ACCGE\nEBeW7Oe3zKoTQgghhOgmKZyEiAqHw7S3txMOh1M9FNOTXCcm+dHH7PkyWnw9HY/R4tFLCichojwe\nD++88w4ejyfVQzE9yXVikh99zJ4vo8XX0/EYLR69pHASQgghhOgmKZyEiFIUhbS0NLmR6TdAcp2Y\n5Ecfs+fLaPH1dDxGi0cvmVXXQzKrTgghhOh/ZFadEEIIIUQfk8JJCCGEEKKbpHASIsrtdvPGG2/g\ndrtTPRTTk1wnJvnRx+z5Mlp8PR2P0eLRSwonIYQQQohuksJJCCGEEKKbZFZdD8msOvNQVZVgMNiv\np8n2F5LrxCQ/+pg9X0aLr6fjMUo838isuscee4wpU6aQnZ1NYWEhs2fPpq6uLq6Pz+fjnnvuYcCA\nAWRlZTF37lxOnDgR1+fYsWPMmjWLjIwMCgsLuf/++wkGg3F93n//fSZOnIjD4WDkyJGsX7++03ie\ne+45hg8fjtPppLy8nD/96U99MhZxcVAUBZvNZoj/mMxOcp2Y5Ecfs+fLaPH1dDxGi0evND2dt2/f\nzj333MOUKVMIBoM89NBDVFZW8umnn5KZmQnAfffdx5tvvslrr71Gbm4u1dXVfO9732Pnzp0AhEIh\nZs2axaBBg9i1axfHjx/n9ttvx2az8eijjwJw+PBhZs2axd13382LL77Itm3b+OEPf0hxcTFVVVUA\nvPrqqyxZsoR169ZRXl7OmjVrqKqqoq6ujsLCwl4bixBCCCFg+INv9mj9I4/P6qWRpFaPTtWdPHmS\nwsJCtm/fzvTp02lubmbgwIG89NJLfP/73wfg0KFDjBkzBpfLxVVXXcXbb7/N3/3d31FfX09RUREA\n69atY+nSpZw8eRK73c7SpUt58803qa2t1X7XvHnzcLvdbN68GYDy8nKmTJnCs88+C0QeGlhaWsq9\n997Lgw8+2GtjOZff78fv92s/ezweSktLOXr0KDk5OTgcDtLT07W+7e3tANhsNq24DAQCeL1eAKxW\nK9nZ2UCkkGtpaQHAYrFohw5VVaW5uVn7nXl5edr3zc3NxDZhTk4OFotFG1fsAYpZWVmkpUVq5NbW\nVu2IWkZGhhZjW1sbHR0dADidTpxOJxA5aufz+QBMH1sgEMDlcjFp0iTtNc0Sm9G2WzgcZs+ePVRU\nVGCxWEwVW29sN6/XyyeffMLUqVPJyckxVWx9sd08Hg+7du1i/Pjx2vpmiS02/l27dvHtb3+bzMzM\nlMV27VMf0tyhUJyhsmh0iN8ftfC/PoX2IJzyR44eOawqAyOr0hGCRl+k3WZR2fPANdrv+uSTT6io\nqCA7Oztl+2RjYyNFRUW6T9XpOuJ0rliwBQUFAOzdu5dAIMDMmTO1PqNHj2bo0KFaseJyuRg/frxW\nqABUVVWxaNEiDhw4wJVXXonL5Yp7jVifxYsXA9DR0cHevXv56U9/qi23WCzMnDkTl8vVq2M512OP\nPcaKFSs6te/cuZOMjAxGjBjBuHHjAGhoaGDfvn0AlJSUMGXKFACampq0cebn5zN9+nQAvF4v27dv\nByIbN3Z0LRgMau0AN998s/b9hx9+qO0olZWV2hu2pqZGewNOmzZN20b79+/n5MmTAEyePJnBgwcD\nUFdXx7FjxwAYO3YsI0eOBODIkSPa6VizxzZkyBB8Ph8nT57ks88+M1VsRttuEyZMwOfzEQ6Hqa2t\nNVVsvbXdAO3DwWyx9fZ2C4fD+P1+ampqTBcbRAqtjo4OLb5UxTajWGHjUStWBXIdcNdlkf3z41MK\n6z+zAlCWpbLo8kj74RZYUxspMwY40GKz2+10dHQQDodTuk/G2vRK+ohTOBzm7//+73G73Xz44YcA\nvPTSS9x1111xR2QAvvOd7zBjxgyeeOIJFi5cyNGjR9myZYu2vK2tjczMTN566y1uvPFGLrvsMu66\n6664wuitt95i1qxZtLW10dTUxODBg9m1axcVFRVanwceeIDt27eze/fuXhvLueSIk3lj8/v9bN++\nnalTp2Kz2UwVm9G2WygU4sMPP+Taa68lLS3NVLH1xnZraWnho48+4tprryUvL89UsfXFdnO73Wzf\nvp2JEydq/cwSG0QKrR07dmjxpfqI05BMlfu/HWLD5xYa2/UfcWptbWXv3r1ce+212sXZMaY+4nTP\nPfdQW1urFU2JqKrarYvAEvWJJe9CfS70e3o6FofDgcPh6NSel5fXKfHn62uz2eJ2jhir1dplu6Io\nXbYD5Obmdtl+vp0gKyury/aMjAwyMjI6tZ+9k53NjLHZ7XZmzJhBZmYmVqu1U//+HFuMUbZbKBRK\nmGvov7GdLdntlp2dTW5urvZBa6bYztUbsWVnZyfcn/pzbLFxni++bzK25o7I5+KJdnhsn5VTfgiE\n4z8r/SGFr7ydXz8QPrPvnb29Ur1PJiOp+zhVV1ezadMm3nvvPYYMGaK1Dxo0iI6Ojk53A41VdbE+\n585si/2cqE9jYyM5OTk4nU4uueQSrFZrl33Ofo3eGIu4eFitVnJycs77QS56j+Q6McmPPmbPl9Hi\nC4QVGtqVTkVTdxktHr10FU6qqlJdXc3rr7/Ou+++S1lZWdzySZMmYbPZ2LZtm9b22WefcezYMe2U\nWkVFBZ988gmNjY1an61bt5KTk8Pll1+u9Tn7NWJ9Yq9ht9uZNGlSXJ9wOMy2bdu0Pr01FiGEEEKI\nGF2F0z333MPvfvc7XnrpJbKzs2loaKChoUE7h5ubm8uCBQtYsmQJ7733Hnv37uXOO++koqKCq666\nCohc4HX55ZfzT//0T/z5z39my5YtPPzww9xzzz3aIc27776bL7/8kgceeIBDhw7x61//mv/6r//i\nvvvu08ayZMkSnn/+eTZs2MDBgwdZtGgRXq+Xu+66q1fHIi4eLS0t7NixQ7vGQPQdyXVikh99zJ4v\no8VX6FRZPC5IoTO5SflGi0cvXdc4rV27FoDrrrsurv23v/0td955JwC//OUvsVgszJ07F7/fT1VV\nFb/+9a+1vlarlU2bNrFo0SIqKirIzMzkjjvuYOXKlVqfsrIy3nzzTZYsWcLTTz/NkCFD+I//+A9t\nhgHAD37wA06ePMmyZctoaGhgwoQJbN68Oe4UW2+MRVw8QqEQTU1NhEKhVA/F9CTXiUl+9DF7vowW\nn90KZdmRr8kwWjx66SqcujMBz+l08txzz/Hcc8+dt8+wYcN46623Er7OjBkz+PjjjxP2qa6uprq6\nus/HIoQQQggB8pBfITSZmZnakUfRtyTXiUl+9DF7vowW30kfrP3UwklfcusbLR69enQDTCHMxGaz\naY/rEX1Lcp2Y5Ecfs+fLaPH5QwqHmpN/zpzR4tFLjjgJIYQQQnSTFE5CRHm9Xvbs2aPd0Vf0Hcl1\nYpIffcyeL6PFN8ChcudlIQY4kptVZ7R49JLCSYioQCBAfX09gUAg1UMxPcl1YpIffcyeL6PFl54G\nVw5QSU/yYh+jxaOXFE5CCCGEEN0khZMQUenp6UyYMEF7QKfoO5LrxCQ/+pg9X0aLr8kPL39pocl/\n4b5dMVo8esmsOiGiHA4Hw4YNS/UwLgqS68QkP/qYPV9Gi88bVPhjY/Kz6owWj15yxEkIIYQQopuk\ncBIiqr29ndraWu3Zi6LvSK4Tk/zoY/Z8GS2+XLvK7GEhcu3JzaozWjx6SeEkRJTf7+fLL7/E70/y\nxL3oNsl1YpIffcyeL6PFl22DGSUq2bbk1jdaPHpJ4SSEEEII0U1SOAkR5XQ6GTVqFE6nM9VDMT3J\ndWKSH33Mni+jxefpgLf/quDpSG59o8Wjl6KqanInKQUAHo+H3NxcmpubycnJSfVwhBBCiD4x/ME3\ne7T+kcdn9dJIekeyn99yxEkIIYQQopukcBIiyufz8cUXX+Dz+VI9FNOTXCcm+dHH7PkyWnzZNpXr\nisNk25I7YWW0ePSSwkmIKJ/Px4EDB/rtm7k/kVwnJvnRx+z5Mlp8uXaYMzxMrj259Y0Wj15SOAkh\nhBBCdJM8ckWIKLvdztChQ7Hbk/wzSnSb5DoxyY8+Zs9Xb8bX0wu8AbwBcJ1Q8AaSW7+/by+ZVddD\nMqtOCCFEf9EbhVOyZFadEEIIIcRFRgonIaI6Ojr4+uuv6ehI8q5uotsk14lJfvQxe76MFl+6VWVC\nQZh0a3InrIwWj15SOAkR1dbWRk1NDW1tbakeiulJrhOT/Ohj9nwZLb4BTrhrVJgBSd7422jx6CWF\nkxBCCCFEN0nhJERUWloaAwcOJC1NJpv2Ncl1YpIffcyeL6PF5w/BQbeCP5Tc+kaLRy+ZVddDMqtO\nCCFEfyGz6s6QWXVCCCGEEH1MCichooLBIKdPnyYYDKZ6KKYnuU5M8qOP2fNltPjsFpXhWSp2S3In\nrIwWj15SOAkR1draygcffEBra2uqh2J6kuvEJD/6mD1fRouvMB3uGx+iMD259Y0Wj15SOAkhhBBC\ndJMUTkJEWSwWsrOzsVjkbdHXJNeJSX70MXu+jBZfIAzH2yJfk2G0ePSSWXU9JLPqhBBC9Bcyq+6M\nb2xW3Y4dO7jpppsoKSlBURQ2btwYt1xRlC7/Pfnkk1qf4cOHd1r++OOPx73O/v37mTZtGk6nk9LS\nUlavXt1pLK+99hqjR4/G6XQyfvx43nrrrbjlqqqybNkyiouLSU9PZ+bMmXz++edxfU6fPs1tt91G\nTk4OeXl5LFiwoN+edxVCCCFE39JdOHm9Xq644gqeffbZLpcfP3487t8LL7yAoijMnTs3rt/KlSvj\n+t17773aMo/HQ2VlJcOGDWPv3r08+eSTLF++nOeff17r43K5mD9/PgsWLODjjz9mzpw5zJ49m9ra\nWq3P6tWreeaZZ1i7di27d+8mMzOTqqoqfD6f1ue2227jwIEDbN26lU2bNrFjxw4WLlyoNy3CBMLh\nMO3t7YTDSR5/Ft0muU5M8qOP2fNltPisikquXcWqJHfCymjx6KW7cLrxxht55JFH+N73vtfl8kGD\nBsX9e+ONN5gxYwbf+ta34vplZ2fH9cvMzNSWvfjii3R0dPDCCy8wduxY5s2bx49//GOeeuoprc+a\nNWu44YYbuP/++xkzZgwrV65k4sSJWkGnqipr1qzh4YcfZvbs2Xz729/mP//zP6mvr9eOkh08eJDN\nmzfzH//xH5SXl3PNNdfwq1/9ildeeYX6+nq9qRH9nMfj4Z133sHj8aR6KKYnuU5M8qOP2fNltPiK\nM2DlpBDFGcmtb7R49OrT+52fOHGCN998kw0bNnRa9vjjj7Nq1SqGDh3Krbfeyn333afdft3lcjF9\n+nTsdrvWv6qqiieeeIKmpiby8/NxuVwsWbIk7jWrqqq0oujw4cM0NDQwc+ZMbXlubi7l5eW4XC7m\nzZuHy+UiLy+PyZMna31mzpyJxWJh9+7dzJkzp9O4/X4/fr9f+zm24d1uN+FwGIfDQXp6uta3vb0d\nAJvNphWHgUAAr9cLgNVqJTs7G4BQKERLSwsQuXguds5VVVWam5u135mXl6d939zcTOwytZycHO1i\nO4/Ho1XzWVlZWm5bW1u1e2dkZGRoOW5ra9OeVO10OnE6I09v9Pl82hE6s8cWEwgEcLvdporNaNst\nFDrzrAazxdYb2y02rhgzxQZ9s92AuLyZKbbY2GPLehLbQKeKwxpZ95QP2kMKAPl2lUxb9DU7oCUQ\nac+xqeREP4pbAtDcoWi/uzA98nvbg3DKH2l3WFUGRh/+2xGCRl+k3WZRtf9Xz74cJtX7ZDL6tHDa\nsGED2dnZnY5O/fjHP2bixIkUFBSwa9cufvrTn3L8+HHtiFJDQwNlZWVx6xQVFWnL8vPzaWho0NrO\n7tPQ0KD1O3u98/UpLCyMW56WlkZBQYHW51yPPfYYK1as6NS+c+dOMjIyGDFiBOPGjdNef9++fQCU\nlJQwZcoUAJqamnC5XADk5+czffp0IHIadPv27UBk41ZVVQGRm4XF2gFuvvlm7fsPP/xQ21EqKyu1\nN2xNTY32Jps2bRoFBQVA5NqxkydPAjB58mQGDx4MQF1dHceOHQNg7NixjBw5EoAjR45QV1cHYPrY\nSktLSUtL43//93/57LPPTBWb0bbblVdeSVpaGoqimC623tpuses/zRhbb283RVGwWq189NFHposN\n0IqEWHw9iW1uWZgxeZFi5Ld1FvadjuxjVUPCVBRF2l8/YuH945H2qUVhbiyNtL9Xr7DxqBVVhUAI\n7rg0Mq6PTyms/yxSjZVlqSy6PNJ+uAXW1EbKjAEOtNjsdrv2/k/lPhlr06tHs+oUReH1119n9uzZ\nXS4fPXo0f/u3f8uvfvWrhK/zwgsv8C//8i+0trbicDiorKykrKyM3/zmN1qfAwcOMG7cOA4ePMjo\n0aOx2+1s2LCB+fPna32ee+45Vq1aRUNDA7t27eLqq6+mvr6e4uJirc8tt9yC1WrllVde4dFHH2XD\nhg3aDh8zcOBAVq1axd13391prF0dcSotLeXo0aPk5OSY9i9gMO9f9xKbxCaxSWwXS2xTlm/qlSNO\nmWkq+dED9d094rTngWv6NDa9262xsZGioiLds+r67IjTBx98QF1dHa+++uoF+5aXlxMMBjly5Aij\nRo1i0KBBnDhxIq5PY2MjcOYI0vn6nL0cIqcLzy6cGhsbmTBhgtYn9roxwWCQpqamTkeqYhwOR9xp\nnZi8vLxOiT9fX5vNFrdzxFit1i7bFUXpsh0ipx+7cr6dICsrq8v2jIwMMjI6n7A+eyc7m8R2hsQW\nT2I7Q2I7Q2I7I5WxnfQpXbY3dSg0dXRu9wQUPIHO7d6ggreLJ6b4QwpfeTu3B8Jdx5Dq7ZaMPrv7\n1P/7f/+PSZMmccUVV1yw7759+7BYLNpps4qKCnbs2EEgcGZrbd26lVGjRpGfn6/12bZtW9zrbN26\nlYqKCgDKysoYNGhQXB+Px8Pu3bu1PhUVFbjdbvbu3av1effddwmHw5SXlycZuRBCCCHMSnfh1Nra\nyr59+7TztocPH2bfvn1x5wo9Hg+vvfYaP/zhDzut73K5WLNmDX/+85/5y1/+wosvvsh9993HP/7j\nP2pF0a233ordbmfBggUcOHCAV199laeffjruYvCf/OQnvP322/ziF7/g0KFDLF++nJqaGqqrq4FI\nFbt48WIeeeQR/vu//5tPPvmE22+/nZKSEu3U4pgxY7jhhhv40Y9+xJ/+9Cd27txJdXU18+bNo6Sk\nRG9qRD/ndrt54403tAsYRd+RXCcm+dHH7PkyWnxDMlWerggyJDO5K32MFo9euk/V1dTUMGPGDO3n\nWDFzxx13sH79egBeeeUVVFWNu/4oxuFw8Morr7B8+XL8fj9lZWXcd999cUVRbm4uW7Zsobq6mkmT\nJnHJJZewbNmyuPsrTZ06lZdffpmHH36Yhx56iEsvvZSNGzdqF+UBPPDAA3i9XhYuXIjb7eaaa65h\n8+bNcYfnXnzxRaqrq7n++uuxWCzMnTuXZ555Rm9ahBBCCHER0F04XXfddVzoevKFCxee9yaSEydO\n5I9//OMFf88VV1zBBx98kLDPLbfcwi233HLe5YqisHLlSlauXHnePgUFBbz00ksXHI8QQgghhDyr\nrofkWXXmoaoqwWBQmyYr+o7kOjHJjz5mz1dvxtcbz6pTULFbI7PmVLo/ntiz6oyyvZL9/O7T+zgJ\n0Z8oioLNZkv1MC4KkuvEJD/6mD1fRotPRcEfunC/8zFaPHr12aw6IYQQQgizkcJJiCiPx8OWLVv6\n7fOT+hPJdWKSH33Mni+jxVecobJiYpDijOSu9DFaPHpJ4SREVDgcxufz9dsndvcnkuvEJD/6mD1f\nRovPqkCeI/I1GUaLRy8pnIQQQgghuklm1fWQzKozj1AohNfrJTMzE6vVmurhmJrkOjHJjz5mz1dv\nxtcbs+psFpUBDjjljzxKpbtis+qMsr1kVp0QPWS1WqX4/YZIrhOT/Ohj9nwZLb5AWKGhPfn1jRaP\nXnKqTgghhBCim6RwEiKqpaWFHTt20NLSkuqhmJ7kOjHJjz5mz5fR4it0qiweF6TQmdyVPkaLRy8p\nnISICoVCNDU1EQr14M5uolsk14lJfvQxe76MFp/dCmXZka/JMFo8eknhJIQQQgjRTVI4CRGVmZlJ\nRUUFmZmZqR6K6UmuE5P86GP2fBktvpM+WPuphZO+5NY3Wjx6yaw6IaJsNhuFhYWpHsZFQXKdmORH\nH7Pny2jx+UMKh5qTfziv0eLRS444CSGEEEJ0kxROQkR5vV727NmD1+tN9VBMT3KdmORHH7Pny2jx\nDXCo3HlZiAGO5GbVGS0evaRwEiIqEAhQX19PIBBI9VBMT3KdmORHH7Pny2jxpafBlQNU0pO82Mdo\n8eglhZMQQgghRDdJ4SREVHp6OhMmTCA9PT3VQzE9yXVikh99zJ4vo8XX5IeXv7TQ5E9ufaPFo5fM\nqhMiyuFwMGzYsFQP46IguU5M8qOP2fNltPi8QYU/NiY/q85o8eglR5yEEEIIIbpJCichotrb26mt\nraW9vQeP/RbdIrlOTPKjj9nzZbT4cu0qs4eFyLUnN6vOaPHoJYWTEFF+v58vv/wSvz/JE/ei2yTX\niUl+9DF7vowWX7YNZpSoZNuSW99o8eglhZMQQgghRDdJ4SRElNPpZNSoUTidzlQPxfQk14lJfvQx\ne76MFp+nA97+q4KnI7n1jRaPXoqqqsmdpBQAeDwecnNzaW5uJicnJ9XDEUIIIc5r+INvpux3H3l8\nVsp+d1eS/fyWI05CCCGEEN0khZMQUT6fjy+++AKfz5fqoZie5DoxyY8+Zs+X0eLLtqlcVxwm25bc\nCSujxaOXFE5CRPl8Pg4cONBv38z9ieQ6McmPPmbPl9Hiy7XDnOFhcu3JrW+0ePSSwkkIIYQQopuk\ncBIiym63M3ToUOz2JP+MEt0muU5M8qOP2fNltPi8AXCdUPAGklvfaPHoJbPqekhm1QkhhOgvZFbd\nGTKrTgghhBCij+kunHbs2MFNN91ESUkJiqKwcePGuOV33nkniqLE/bvhhhvi+pw+fZrbbruNnJwc\n8vLyWLBgAa2trXF99u/fz7Rp03A6nZSWlrJ69epOY3nttdcYPXo0TqeT8ePH89Zbb8UtV1WVZcuW\nUVxcTHp6OjNnzuTzzz/XPRZxcejo6ODrr7+moyPJu7qJbpNcJyb50cfs+TJafOlWlQkFYdKtyZ2w\nMlo8eukunLxeL1dccQXPPvvsefvccMMNHD9+XPv38ssvxy2/7bbbOHDgAFu3bmXTpk3s2LGDhQsX\nass9Hg+VlZUMGzaMvXv38uSTT7J8+XKef/55rY/L5WL+/PksWLCAjz/+mDlz5jB79mxqa2u1PqtX\nr+aZZ55h7dq17N69m8zMTKqqquKu5L/QWMTFo62tjZqaGtra2lI9FNOTXCcm+dHH7PkyWnwDnHDX\nqDADkrzxt9Hi0StN7wo33ngjN954Y8I+DoeDQYMGdbns4MGDbN68mT179jB58mQAfvWrX/Hd736X\n//t//y8lJSW8+OKLdHR08MILL2C32xk7diz79u3jqaee0oqaNWvWcMMNN3D//fcDsHLlSt555x2e\nffZZ1q1bh6qqrFmzhocffpjZs2cD8J//+Z8UFRWxceNG5s2b162xCCGEEELE6C6cuuP999+nsLCQ\n/Px8/uZv/oZHHnmEAQMGAJEjRXl5eVqhAjBz5kwsFgu7d+9mzpw5uFwupk+fHnfFfVVVFU888QRN\nTU3k5+fjcrlYsmRJ3O+tqqrSTh0ePnyYhoYGZs6cqS3Pzc2lvLwcl8vFvHnzujWWc/n9/rgnOns8\nHgDcbjfhcBiHw0F6errWt729HQCbzUZmZiYAgUAAr9cLgNVqJTs7G4BQKERLSwsAFotFu1hNVVWa\nm5u135mXl6d939zcTOz6/pycHCwWizaucDgMQFZWFmlpkU3d2tpKMBgEICMjQ8txW1ubdtjU6XRq\nzxDy+XzaETqzx5aWlsbAgQMJh8O43W5TxWa07QYwcOBA0tLSTBdbb2y3trY2CgoKtNcxU2x9sd3S\n0tK45JJL4o5gmCW2WJ+8vDwtvp7ENtCp4rBG1j3lg/aQAkC+XSXTFn3NDmgJRNpzbCo50Y/ilgA0\ndyj4Q/BZc2QdgPYgnPJH+jusKgOjR6I6QtDoi7TbLKr2/6rP59Pe/6neJ5PR64XTDTfcwPe+9z3K\nysr48ssveeihh7jxxhtxuVxYrVYaGhooLCyMH0RaGgUFBTQ0NADQ0NBAWVlZXJ+ioiJtWX5+Pg0N\nDVrb2X3Ofo2z1ztfnwuN5VyPPfYYK1as6NS+c+dOMjIyGDFiBOPGjdNef9++fQCUlJQwZcoUAJqa\nmnC5XADk5+czffp0IHIadPv27UBk41ZVVQEQDAa1doCbb75Z+/7DDz/UdpTKykrtDVtTU6O9AadN\nm0ZBQQHPmnlAAAAgAElEQVQQuXbs5MmTAEyePJnBgwcDUFdXx7FjxwAYO3YsI0eOBODIkSPU1dUB\nXBSxTZ06laNHj5oyNqNtt6lTpwKwa9cu08XWW9stKyvLtLH15nbLysriO9/5Ttx1rmaJLfa92+1m\nz549PY5tblmYMXmRYuS3dRb2nY4UNlVDwlQURdpfP2Lh/eOR9qlFYW4sjbS/V6+w8aiVkz6Fvf9r\n4YejI8XLx6cU1n8WqcbKslQWXR5pP9wCa2ojZcYAB13GFggEUrZPxtr06tHtCBRF4fXXX9dOhXXl\nL3/5CyNGjOB//ud/uP7663n00UfZsGGDtpPFDBw4kFWrVnH33XdTWVlJWVkZv/nNb7TlBw4cYNy4\ncRw8eJDRo0djt9vZsGED8+fP1/o899xzrFq1ioaGBnbt2sXVV19NfX09xcXFWp9bbrkFq9XKK6+8\n0q2xnKurI06lpaUcPXqUnJwc0/4FDOb9615ik9gkNontYoltyvJNPT7iBJCZppLviLR394jTngeu\n6dPY9G63xsZGioqKdN+OoE9O1Z3tW9/6FpdccglffPEF119/PYMGDaKxsTGuTzAYpKmpSTs6NGjQ\nIE6cOBHXJ7bOhfqcvRzgxIkTcYVTY2MjEyZM0PpcaCzncjgcOByOTu15eXmdEn++vjabLW7niIkd\njj2XoihdtkPk9GNXzrcTxP6CPVdGRgYZGRmd2s/eyc5mxtiCwSAej0ebYXmu/hxbjFG2WzAY5PTp\n0+Tk5JgutrMlG1tsX7TZbKSlpZkqtnP1Rmxnv3djH6Jn68+xQaSgCofDXcanN7aT0ULmXE0dCk1d\nTHLzBBQ859zo0m6JFEf1bdARjn89f0jhK2/n1wmEz+x7Z7//09LSUrpPJqPPC6evvvqKU6dOacVL\nRUUFbrebvXv3MmnSJADeffddwuEw5eXlWp+f/exnBAIBbLZICbx161ZGjRpFfn6+1mfbtm0sXrxY\n+11bt26loqICgLKyMgYNGsS2bdu0Qsnj8bB7924WLVrU7bGIi0draysffPAB11577XnfyKJ3SK4T\nk/zoY/Z8nRtfKm9iCVCYDveND/HkfmuXRdKF9Pftpft2BK2trezbt087b3v48GH27dvHsWPHaG1t\n5f777+ePf/wjR44cYdu2bdx8882MHDlSO585ZswYbrjhBn70ox/xpz/9iZ07d1JdXc28efO0WWy3\n3nordrudBQsWcODAAV599VWefvrpuIvBf/KTn/D222/zi1/8gkOHDrF8+XJqamqorq4GIn9ZLV68\nmEceeYT//u//5pNPPuH222+npKREO7XYnbEIIYQQQsToPuJUU1PDjBkztJ9jxcwdd9zB2rVr2b9/\nPxs2bMDtdlNSUkJlZSWrVq2KO1z54osvUl1dzfXXX4/FYmHu3Lk888wz2vLc3Fy2bNlCdXU1kyZN\n4pJLLmHZsmVx91eaOnUqL7/8Mg8//DAPPfQQl156KRs3btQuygN44IEH8Hq9LFy4ELfbzTXXXMPm\nzZvjDs9daCzi4mGxWMjOztbOo4u+I7lOTPKjj9nzZbT4AmE43hb5mgyjxaOXPKuuh+RZdUIIIb5J\nqT5Vlyx5Vp0QQgghxEVGCichosLhMO3t7XE3aRR9Q3KdmORHH7Pny2jxWRWVXLuKVUnuhJXR4tFL\nCichojweD++88452N3jRdyTXiUl+9DF7vowWX3EGrJwUorjzDP9uMVo8eknhJIQQQgjRTVI4CRGl\nKAppaWkoStc3iBO9R3KdmORHH7Pny2jxqSr4gpGvyTBaPHrJrLoekll1Qgghvkkyq653yKw6IYQQ\nQog+JoWTEEIIIUQ3SeEkRJTb7eaNN97A7XaneiimJ7lOTPKjj9nzZbT4hmSqPF0RZEhmclf6GC0e\nvaRwEkIIIYToJimchBBCCCG6SWbV9ZDMqjMPVVUJBoP9eppsfyG5Tkzyo4/Z83VufKmeVaegYrdC\nRwhUup/v2Kw6o2yvZD+/0/pwTEL0K4qiYLPZUj2Mi4LkOjHJjz5mz5fR4lNR8IeSX99o8eglp+qE\nEEIIIbpJCichojweD1u2bOm3z0/qTyTXiUl+9DF7vowWX3GGyoqJQYozkrvSx2jx6CWFkxBR4XAY\nn8/Xb5/Y3Z9IrhOT/Ohj9nwZLT6rAnmOyNdkGC0evaRwEkIIIYToJplV10Myq848QqEQXq+XzMxM\nrFZrqodjapLrxCQ/+pg9X+fGl+pZdTaLygAHnPJDIKx/Vp1RtpfMqhOih6xWqxS/3xDJdWKSH33M\nni+jxRcIKzS0J7++0eLRS07VCSGEEEJ0kxROQkS1tLSwY8cOWlpaUj0U05NcJyb50cfs+TJafIVO\nlcXjghQ6k7vSx2jx6CWFkxBRoVCIpqYmQqEe3NlNdIvkOjHJjz5mz5fR4rNboSw78jUZRotHLymc\nhBBCCCG6SQonIaIyMzOpqKggMzMz1UMxPcl1YpIffcyeL6PFd9IHaz+1cNKX3PpGi0cvmVUnRJTN\nZqOwsDDVw7goSK4Tk/zoY/Z8GS0+f0jhUHPyD+c1Wjx6yREnIYQQQohuksJJiCiv18uePXvwer2p\nHorpSa4Tk/zoY/Z8GS2+AQ6VOy8LMcCR3Kw6o8WjlxROQkQFAgHq6+sJBAKpHorpSa4Tk/zoY/Z8\nGS2+9DS4coBKepIX+xgtHr2kcBJCCCGE6CYpnISISk9PZ8KECaSnp6d6KKYnuU5M8qOP2fNltPia\n/PDylxaa/Mmtb7R49JJZdUJEORwOhg0bluphXBQk14lJfvQxe76MFp83qPDHxuRn1RktHr3kiJMQ\nQgghRDdJ4SREVHt7O7W1tbS39+Cx36JbJNeJSX70MXu+jBZfrl1l9rAQufbkZtUZLR69dBdOO3bs\n4KabbqKkpARFUdi4caO2LBAIsHTpUsaPH09mZiYlJSXcfvvt1NfXx73G8OHDURQl7t/jjz8e12f/\n/v1MmzYNp9NJaWkpq1ev7jSW1157jdGjR+N0Ohk/fjxvvfVW3HJVVVm2bBnFxcWkp6czc+ZMPv/8\n87g+p0+f5rbbbiMnJ4e8vDwWLFhAa2ur3rQIE/D7/Xz55Zf4/UmeuBfdJrlOTPKjj9nzZbT4sm0w\no0Ql25bc+kaLRy/dhZPX6+WKK67g2Wef7bSsra2Njz76iJ///Od89NFH/P73v6euro6///u/79R3\n5cqVHD9+XPt37733ass8Hg+VlZUMGzaMvXv38uSTT7J8+XKef/55rY/L5WL+/PksWLCAjz/+mDlz\n5jB79mxqa2u1PqtXr+aZZ55h7dq17N69m8zMTKqqqvD5ztwn/rbbbuPAgQNs3bqVTZs2sWPHDhYu\nXKg3LUIIIYS4CCiqqiZ3rA1QFIXXX3+d2bNnn7fPnj17+M53vsPRo0cZOnQoEDnitHjxYhYvXtzl\nOmvXruVnP/sZDQ0N2O12AB588EE2btzIoUOHAPjBD36A1+tl06ZN2npXXXUVEyZMYN26daiqSklJ\nCf/6r//Kv/3bvwHQ3NxMUVER69evZ968eRw8eJDLL7+cPXv2MHnyZAA2b97Md7/7Xb766itKSkou\nmAOPx0Nubi7Nzc3k5OR0I2vCqHw+H0eOHGH48OE4nc5UD8fUJNeJSX70MXu+zo1v+INvpnQ8OTaV\nqUVhdp2w4Al0/yLxI4/PAoyzvZL9/O7zWXXNzc0oikJeXl5c++OPP86qVasYOnQot956K/fddx9p\naZHhuFwupk+frhVNAFVVVTzxxBM0NTWRn5+Py+ViyZIlca9ZVVWlnTo8fPgwDQ0NzJw5U1uem5tL\neXk5LpeLefPm4XK5yMvL04omgJkzZ2KxWNi9ezdz5szpFI/f7487vOjxeABwu92Ew2EcDoc2xdLv\n92vncG02m/ZAw0AgoN0x1Wq1kp2dDUAoFKKlpQUAi8WibUhVVWlubtZ+59m5bG5uJlb75uTkYLFY\ntHGFw2EAsrKytNy2trYSDAYByMjI0HLc1tZGR0cHAE6nU9uZfT6fdoTuYoht9OjR+P1+3G636WIz\n2nYbPXq0aWPrje02bNgwrd1ssfX2dnM6nYwaNYrm5mbtd5gltthrDho0KO73xAzOUFGitcvxNgip\nkR+K0lVs0XNKje3QEY60D3SqOKyR9lM+aA9F2vPtKpnRU2/NHdASLYhybCo50Y/ilgA0dyh4Agof\nNFjId0COXaU9CKf8kf4Oq8rAaC3UEYJGX6TdZlG1/1ctFov2/k/1PpmMPi2cfD4fS5cuZf78+XHV\n3I9//GMmTpxIQUEBu3bt4qc//SnHjx/nqaeeAqChoYGysrK41yoqKtKW5efn09DQoLWd3aehoUHr\nd/Z65+tz7oMG09LSKCgo0Pqc67HHHmPFihWd2nfu3ElGRgYjRoxg3Lhx2uvv27cPgJKSEqZMmQJA\nU1MTLpcLgPz8fKZPnw5EToNu374diGzcqqoqAILBoNYOcPPNN2vff/jhh9qOUllZqb1ha2pqtDfg\ntGnTKCgoACLXjp08eRKAyZMnM3jwYADq6uo4duwYAGPHjmXkyJEAHDlyhLq6OgCJTWKT2CQ2ic0A\nsZ390f3jsSGc0R+X7bXSHKkPuOuyEMUZke9/+YmVI9FLd+eWhRmTFylGfltnYd/pSGFTNSRMRVGk\n/fUjFt4/HmmfWhTmxtJI+3v1ChuPRqqu8QUq80dEipePTyms/yzSXpalsujySPvhFlhTGxncAAeG\n226xNr367FRdIBBg7ty5fPXVV7z//vsJD4O98MIL/Mu//Autra04HA4qKyspKyvjN7/5jdbnwIED\njBs3joMHDzJ69GjsdjsbNmxg/vz5Wp/nnnuOVatW0dDQwK5du7j66qupr6+nuLhY63PLLbdgtVp5\n5ZVXePTRR9mwYYO2w8cMHDiQVatWcffdd3caa1dHnEpLSzl69Cg5OTmm/gvY7LEpisJXX31FYWGh\n9vpmic1o2y0tLY2GhgaGDBlCMBg0VWy9sd06Ojo4deoUZWVlOJ1OU8XWF9vN5/Px17/+ldzcXG0c\nZokNIrPQvvjiC4qKirDb7Ux4fKcWWyqOOGXbVCoKwxxpVWgLKt0+4rTngWu0+JubmxkyZAgOhyNl\n+2RjYyNFRUXGOFUXCAT4h3/4B44ePcq77757wQGVl5cTDAY5cuQIo0aNYtCgQZw4cSKuT2NjI3Dm\nCNL5+py9HODEiRNxhVNjYyMTJkzQ+sReNyYYDNLU1NTpSFWMw+HA4XB0as/Ly+sU5/n62my2Tqcu\nIfIG6qq9q1OdMbm5uV22ny/nWVlZXbZnZGSQkZHRqf3snexsZozN7XZz4MABLrnkki7H1J9jizHK\ndrtQrqH/xna2ZLeb2+3ms88+o7i4GKfTaarYztUbsfl8Pj799FOuvfbaLtfpz7FBpAD7y1/+Qmlp\naaflX7d1fY3Rifau20/6um5v6lBo6ujc7gkoeM55pFyuHWYNVXlyv4WvvPGv5w8pfNXFs3sD4TP7\n3tnvf6fTmdJ9Mhm9fh+nWNH0+eef8z//8z8MGDDgguvs27cPi8WinTarqKhgx44dcQ8A3Lp1K6NG\njSI/P1/rs23btrjX2bp1KxUVFQCUlZUxaNCguD4ej4fdu3drfSoqKnC73ezdu1fr8+677xIOhykv\nL08yA0IIIYQwK91HnFpbW/niiy+0nw8fPsy+ffsoKCigpKSE73//+3z00Uds2rSJUCikXStUUFCA\n3W7H5XKxe/duZsyYQXZ2Ni6Xi/vuu49//Md/1IqiW2+9lRUrVrBgwQKWLl1KbW0tTz/9NL/85S+1\n3/uTn/yE6dOn84tf/IJZs2bxyiuvUFNTo92yQFEUFi9ezCOPPMKll15KWVkZP//5zykpKdFOLY4Z\nM4YbbriBH/3oR6xbt45AIEB1dTXz5s3r1ow6YS52u52hQ4fGTUoQfUNynZjkRx+z58to8XkD4Dqh\n4A1cuG9XjBaPXrqvcXr//feZMWNGp/Y77riD5cuXd7qoO+a9997juuuu46OPPuL//J//w6FDh/D7\n/ZSVlfFP//RPLFmyJO6Q5p///Geqq6vZs2cPl1xyCffeey9Lly6Ne83XXnuNhx9+mCNHjnDppZey\nevVqvvvd72rLVVXl3//933n++edxu91cc801/PrXv+ayyy7T+pw+fZrq6mr+8Ic/YLFYmDt3Ls88\n88x5D/mdS25HIIQQ4puU6tsRJCt2OwKjSPbzu0cXhwspnIQQQnyzpHDqHcl+fsuz6oSI6ujo4Ouv\nv9ZmX4i+I7lOTPKjj9nzZbT40q0qEwrCpFuTO+5itHj0ksJJiKi2tjZqampoa2tL9VBMT3KdmORH\nH7Pny2jxDXDCXaPCDEjypt9Gi0cvKZyEEEIIIbpJCichotLS0hg4cKB2MzXRdyTXiUl+9DF7vowW\nnz8EB90K/lBy6xstHr3k4vAekovDhRBCfJPk4vDeIReHCyGEEEL0MSmchIgKBoOcPn1ae9aR6DuS\n68QkP/qYPV9Gi89uURmepWK3JHfCymjx6CWFkxBRra2tfPDBB7S2tqZ6KKYnuU5M8qOP2fNltPgK\n0+G+8SEK05Nb32jx6CWFkxBCCCFEN0nhJESUxWIhOzsbi0XeFn1Ncp2Y5Ecfs+fLaPEFwnC8LfI1\nGUaLRy+ZVddDMqtOCCHEN0lm1fUOmVUnhBBCCNHHpHASIiocDtPe3k44nOTxZ9FtkuvEJD/6mD1f\nRovPqqjk2lWsSnInrIwWj15SOAkR5fF4eOedd/B4PKkeiulJrhOT/Ohj9nwZLb7iDFg5KURxRnLr\nGy0evaRwEkIIIYToJimchIhSFIW0tDQURUn1UExPcp2Y5Ecfs+fLaPGpKviCka/JMFo8esmsuh6S\nWXVCCCG+STKrrnfIrDohhBBCiD4mhZMQQgghRDdJ4SRElNvt5o033sDtdqd6KKYnuU5M8qOP2fNl\ntPiGZKo8XRFkSGZyV/oYLR69pHASQgghhOgmKZyEEEIIIbpJZtX1kMyqMw9VVQkGg/16mmx/IblO\nTPKjj9nzdW58qZ5Vp6Bit0JHCFS6n+/YrDqjbK9kP7/T+nBMQvQriqJgs9lSPYyLguQ6McmPPmbP\nl9HiU1Hwh5Jf32jx6CWn6oQQQgghukkKJyGiPB4PW7Zs6bfPT+pPJNeJSX70MXu+jBZfcYbKiolB\nijOSu9LHaPHoJYWTEFHhcBifz9dvn9jdn0iuE5P86GP2fBktPqsCeY7I12QYLR69pHASQgghhOgm\nmVXXQzKrzjxCoRBer5fMzEysVmuqh2NqkuvEJD/69Md86ZkZZ7OoDHDAKT8EwqmfNZjseGKz6oyy\nvWRWnRA9ZLVapfj9hkiuE5P86GP2fAXCCg3tqR7FGT0dT3/fXnKqTgghhBCim6RwEiKqpaWFHTt2\n0NLSkuqhmJ7kOjHJjz5mz1ehU2XxuCCFTmNcWdPT8fT37SWFkxBRoVCIpqYmQqEe3NlNdIvkOjHJ\njz5mz5fdCmXZka9G0NPx9Pftpbtw2rFjBzfddBMlJSUoisLGjRvjlquqyrJlyyguLiY9PZ2ZM2fy\n+eefx/U5ffo0t912Gzk5OeTl5bFgwQJaW1vj+uzfv59p06bhdDopLS1l9erVncby2muvMXr0aJxO\nJ+PHj+ett97qk7EIIYQQQkAShZPX6+WKK67g2Wef7XL56tWreeaZZ1i7di27d+8mMzOTqqoqfD6f\n1ue2227jwIEDbN26lU2bNrFjxw4WLlyoLfd4PFRWVjJs2DD27t3Lk08+yfLly3n++ee1Pi6Xi/nz\n57NgwQI+/vhj5syZw+zZs6mtre3VsYiLR2ZmJhUVFWRmZqZ6KKYnuU5M8qOP2fN10gdrP7Vw0nfh\nvt+Eno6nv2+vHt2OQFEUXn/9dWbPng1EjvCUlJTwr//6r/zbv/0bAM3NzRQVFbF+/XrmzZvHwYMH\nufzyy9mzZw+TJ08GYPPmzXz3u9/lq6++oqSkhLVr1/Kzn/2MhoYG7HY7AA8++CAbN27k0KFDAPzg\nBz/A6/WyadMmbTxXXXUVEyZMYN26db02lnP5/X78fr/2s8fjobS0lKNHj5KTk4PD4SA9PV3r294e\nmXpgs9m0nSQQCOD1eoHI7ILs7Gwgcvgyds7XYrFosw5UVaW5uVn7nXl5edr3zc3NxDZhTk4OFotF\nG1fs5mJZWVmkpUUmULa2thIMBgHIyMjQ8tvW1kZHRwcATqcTp9MJgM/n0wpNiU1ik9gkNomtd2Kb\n8fgWIPKg3EZfZEq/zaJSFFmVkArH2yLtCiqDz6oxvvKeuQXA4AyV2HNyj7dBSI38UJSuYoseGmls\nh47obQMGOlUc0VNsp3zQHoq059tVMqOPj2vugJZApD3HppITCZ+WADR3RNoz01TyHZH29iCc8kfa\nHVaVgZG0dIptzwPXAMbZbo2NjRQVFaX2dgSHDx+moaGBmTNnam25ubmUl5fjcrmYN28eLpeLvLw8\nrVABmDlzJhaLhd27dzNnzhxcLhfTp0/XggaoqqriiSeeoKmpifz8fFwuF0uWLIn7/VVVVdqpw94a\ny7kee+wxVqxY0al9586dZGRkMGLECMaNGwdAQ0MD+/btA6CkpIQpU6YA0NTUhMvlAiA/P5/p06cD\nkaN527dvByIbt6qqCoBgMKi1A9x8883a9x9++KG2o1RWVmpv2JqaGu0/l2nTplFQUABEToGePHkS\ngMmTJzN48GAA6urqOHbsGABjx45l5MiRABw5coS6ujoAiU1ik9gkNomtl2K7/9uR63sOt8Ca2shH\n8QAHWrvbD//+UaTdbj3TDvAT15mP7h+PDeGM/rhsr5XmSH3AXZeFKM6IfP/LT6wciV6BMrcszJi8\nSDHy2zoL+05HCpuqIWEqiiLtrx+x8P7xSPvUojA3lkba36tX2Hg0UnWNL1CZPyJSvHx8SmH9Z5H2\nsiyVRZeHu4zNaNst1qZXrx5x2rVrF1dffTX19fUUFxdr/f7hH/4BRVF49dVXefTRR9mwYYO2k8UU\nFhayYsUKFi1aRGVlJWVlZfzmN7/Rln/66aeMHTuWTz/9lDFjxmC329mwYQPz58/X+vz6179mxYoV\nnDhxotfGci454mTe2MLhMJ9++ikjR45Eif4JZ5bYjLbdFEXhs88+4/LLL0dVVVPF1hvbrb29naNH\njzJ+/HgyMzNNFVtfbDev18uBAwcoLS3VXtfosek54nSJI8wt3wqz47iF5oCS8iNOAxwqs4eH+OOJ\nyHj0HnHy+/0cO3aMyy+/nIyMjIv7iNP5qKqqBZyoT+zD6nzLgQv2SbS8N8bicDhwOByd2vPy8jol\n/nx9bTZb3M4RY7Vau2xXFKXLdogcRevK+XaCrKysLtszMjLIyMjo1H72TnY2M8bmdrupr6/n0ksv\n7XJM/Tm2GKNstwvlGvpvbGfryXY7ceIEo0ePBswX29l6I7ZAIMDx48e57LLLulzHiLGdXfzEBMIK\nX3k7/15nmsLoPPjDMaXTel+3df1ZdaK96/aTvq7bmzoUmjo6t3sCCp5AfFt6Gny7ALZ81Xk8/lDX\nMQTCZ/a9s9//qd4nk9GrtyMYNGgQEHnDny1W1cX6NDY2xi0PBoM0NTXF9enqNYAL9jl7eW+MRQgh\nhBAiplcLp7KyMgYNGsS2bdu0No/Hw+7du6moqACgoqICt9vN3r17tT7vvvsu4XCY8vJyrc+OHTsI\nBM6UuVu3bmXUqFHk5+drfc7+PbE+sd/TW2MRF4/09HQmTJigHWYXfUdynZjkRx+z56vJDy9/aaHJ\nf+G+34Sejqe/by/d1zi1trbyxRdfAHDllVfy1FNPMWPGDAoKChg6dChPPPEEjz/+OBs2bKCsrIyf\n//zn7N+/n08//VQ7LHbjjTdy4sQJ1q1bRyAQ4K677mLy5Mm89NJLQOS85qhRo6isrGTp0qXU1tby\nz//8z/zyl7/UbhWwa9cupk+fzhNPPMGsWbN45ZVXePTRR/noo4+0C/N6YywXIg/5FUIIoZeeh/ya\nRewhv0bxjT3kt6amhhkzZmg/x2a23XHHHaxfv54HHngAr9fLwoULcbvdXHPNNWzevDnuXOKLL75I\ndXU1119/PRaLhblz5/LMM89oy3Nzc9myZQvV1dVMmjSJSy65hGXLlsXdX2nq1Km8/PLLPPzwwzz0\n0ENceumlbNy4USuagF4ZixBCCCFETI9m1Qk54mQm7e3tfPnll4wYMaLfHkLuLyTXiUl+9OmP+dJz\nxCnXrjKjOMx7xy3afZRSKdnxxI44GWV7Jfv5Lc+qEyLK7/fz5Zdfxt1uQvQNyXVikh99zJ6vbBvM\nKFHJtqV6JBE9HU9/315SOAkhhBBCdJMUTkJEOZ1ORo0alfS9PUT3Sa4Tk/zoY/Z8eTrg7b8qeLq4\nz1Iq9HQ8/X17yTVOPSTXOAkhhNBLZtWlnlzjJIQQQgjRx6RwEiLK5/PxxRdfaM+cEn1Hcp2Y5Ecf\ns+cr26ZyXXGYbJsxThD1dDz9fXtJ4SRElM/n48CBA/32zdyfSK4Tk/zoY/Z85dphzvAwufZUjySi\np+Pp79tLCichhBBCiG6SwkmIKLvdztChQ7HbDfJnnYlJrhOT/Ohj9nx5A+A6oeANXLjvN6Gn4+nv\n20tm1fWQzKoTQgihl8yqSz2ZVSeEEEII0cekcBIiqqOjg6+//pqODoPcZc7EJNeJSX70MXu+0q0q\nEwrCpFuNcYKop+Pp79tLCichotra2qipqaGtrS3VQzE9yXVikh99zJ6vAU64a1SYAQa50XZPx9Pf\nt5cUTkIIIYQQ3SSFkxBRaWlpDBw4kLS0tFQPxfQk14lJfvQxe778ITjoVvCHUj2SiJ6Op79vL5lV\n10Myq04IIYReMqsu9WRWnRBCCCFEH5PCSYioYDDI6dOnCQaDqR6K6UmuE5P86GP2fNktKsOzVOwW\nY5wg6ul4+vv2ksJJiKjW1lY++OADWltbUz0U05NcJyb50cfs+SpMh/vGhyhMT/VIIno6nv6+vaRw\nErWqMxsAACAASURBVEIIIYToJimchIiyWCxkZ2djscjboq9JrhOT/Ohj9nwFwnC8LfLVCHo6nv6+\nvWRWXQ/JrDohhBB6yay61JNZdUIIIYQQfUwKJyGiwuEw7e3thMMGOR5uYpLrxCQ/+pg9X1ZFJdeu\nYlWMcYKop+Pp79tLCichojweD++88w4ejyfVQzE9yXVikh99zJ6v4gxYOSlEcUaqRxLR0/H09+0l\nhZMQQgghRDdJ4SRElKIopKWloShKqodiepLrxCQ/+pg9X6oKvmDkqxH0dDz9fXvJrLoekll1Qggh\n9JJZdamX7Od3/3w0sRBCCCH6lZ4Ui0YquuRUnRBCCCFEN0nhJESU2+3mjTfewO12p3oopie5Tkzy\no4/Z8zUkU+XpiiBDMo1xZU1Px2O0ePSSwkkIIYQQopt6vXAaPnw4iqJ0+nfPPfcAcN1113Vadvfd\nd8e9xrFjx5g1axYZGRkUFhZy//33EwwG4/q8//77TJw4EYfDwciRI1m/fn2nsTz33HMMHz4cp9NJ\neXk5f/rTn+KW+3w+7rnnHgYMGEBWVhZz587lxIkTvZsQIYQQQphGr8+qO3nyJKFQSPu5traWv/3b\nv+W9997juuuu47rrruOyyy5j5cqVWp+MjAztivZQKMSECRMYNGgQTz75JMePH+f222/nRz/6EY8+\n+igAhw8fZty4cdx999388Ic/ZNu2bSxevJg333yTqqoqAF599VVuv/121q1bR3l5OWvWrOG1116j\nrq6OwsJCABYtWsSbb77J+vXryc3Npbq6GovFws6dO7sdr8yqMw9VVQkGg/16mmx/IblOTPKjT3/M\nl54LpRVU7FboCIFK6uPr6XiSWb8vLg5P9vO7z29HsHjxYjZt2sTnn3+Ooihcd911TJgwgTVr1nTZ\n/+233+bv/u7vqK+vp6ioCIB169axdOlSTp48id1uZ+nSpbz55pvU1tZq682bNw+3283mzZsBKC8v\nZ8qUKTz77LNA5BbvpaWl3HvvvTz44IM0NzczcOBAXnrpJb7//e8DcOjQIcaMGYPL5eKqq67qVnxS\nOAkhhNDrYrwdQU8YqXDq09sRdHR08Lvf/Y4lS5bE/RXw4osv8rvf/Y5BgwZx00038fOf/5yMjMi9\n210uF+PHj9eKJoCqqioWLVrEgQMHuPLKK3G5XMycOTPud1VVVbF48WLt9+7du5ef/vSn2nKLxcLM\nmTNxuVwA7N27l0AgEPc6o0ePZujQoQkLJ7/fj9/v136O3TLe7XYTDodxOBykp6drfdvb2wGw2Wxk\nZmYCEAgE8Hq9AFitVrKzs4HI0baWlhZtvLENqaoqzc3N2u/My8vTvm9ubiZW++bk5GCxWLRxxZ4D\nlJWVRVpaZFO3trZqpz0zMjKw2+0AtLW10dHRAYDT6cTpdAKR05k+nw9AYpPYJDaJTWLrpdhiF0Z3\nhKDRF/l8tFlUiiKrElLheFukXUFlcKYWDl95z3yeDs5QiX28Hm+DkBr5oShdxRa9GKexHTrCkfaB\nThWHNdJ+ygftoUh7vl0l0xbNVwe0BCLtOTaVnEj4tASguSPSnpmmku+ItLcH4ZQ/0u6wqgyMpKVX\nYwuHw32y3ZLRp4XTxo0bcbvd3HnnnVrbrbfeyrBhwygpKWH//v0sXbqUuro6fv/73wPQ0NAQVzQB\n2s8NDQ0J+3g8Htrb22lqaiIUCnXZ59ChQ9pr2O32uDdXrE/s93TlscceY8WKFZ3ad+7cSUZGBiNG\njGDcuHHa79i3bx8AJSUlTJkyBYCmpiatgMvPz2f69OkAeL1etm/fDkQ2buy0YzAY1NoBbr75Zu37\nDz/8UNtRKisrtTdsTU2N9p/LtGnTKCgoAGD//v2cPHkSgMmTJzN48GAA6urqOHbsGABjx45l5MiR\nABw5coS6ujoA08cWK5qHDRumtZslNqNtt4kTJ/Lpp59SUVFBbW2tqWLrre1mtVqZPn06OTk5pout\nt7ebx+Nh165dcX/UGj22+78duaTlcAusqY18FA9woLW7/fDvH0Xah2apLBl/5oG4P3Gd+ej+8dgQ\nzuiPy/ZaaY7UB9x12Zlnyf3yEytHWiPfzy0LMyYvUrT9ts7CvtORyqRqSJiKokj760csvH880j61\nKMyNpZH29+oVNh61Upyh8uPLQ2REC62PTyms/yxSjZVlqSy6PJwwNk8HhFVYd8jKaf+Z9kSx+f3+\nXt9usTa9+vRUXVVVFXa7nT/84Q/n7fPuu+9y/fXX88UXXzBixAgWLlz4/9u79/imyjx/4J80zaVp\nmxYKvQEtXZRLkYtAqdUBZGCsWphxZEbUlUsRZ0HK/LArXma46u7q6iI4iLK7jmX2xeDI+BrlNVRg\nEJRrGZHLgBeqMEh1aGmVXtMmTZPn90fSQ2PTkNMkzcnp5/169QV9+iT5fr8nlyfPOc85uHTpEvbs\n2SP1aW5uRmxsLHbt2oU777wTQ4cORWFhoceMUmlpKWbMmIGWlhZcvXoVAwYMwNGjR5GXlyf1Wb58\nOQ4dOoRjx45h27ZtKCws9HihAUBOTg6mTZuG559/3mu83macBg0ahEuXLsFsNvObVATnZrPZcODA\nAdx6663Q6XSqyk1p283hcODw4cOYMmUKoqOjVZVbMLZbY2MjTp48iSlTpiAxMVFVuYViu9XV1eHA\ngQMYN26c1E/puU193vUZ58+szKBYJx4f7cTvvoxCdYsm7DNOA2MFlo92SPHInXHqZxQoHOrEi2e0\n+IcFfs04Hfz13UHfbtXV1UhJSVHOrrpLly7h/fffl2aSupKbmwsA0sApNTW10+q39pVu7TNIqamp\nnVa/VVdXw2w2w2g0ol+/ftBqtV77dLyP1tZW1NXVebzAOvbxxmAwwGAwdGpPTEzsVPiu+up0uk4z\nXYDrzcFbu0aj8doOAAkJCV7bu3oSxMXFeW03mUzS7tKOOj7JOlJjbu0D4q5yiOTc2illu3U8347a\ncuuIuV0T6twAID4+3uvflJhbxwFCO7tTg28snR+3/QDq7w+aAOAfzd4Prr7S4r29xuq9vbZVg9rW\nzu0Ndg0a7F5v4jUem8N7Dr5y89YOeObWPmgCgrvduiNk53EqKSlBcnIyCgp8H9DVPo2ZlpYGAMjL\ny8PZs2dRXV0t9dm7dy/MZjOys7OlPvv27fO4n71790qzS3q9HuPHj/fo43Q6sW/fPqnP+PHjodPp\nPPp88cUXqKio8Jilot4jPj4eU6dOlb6xUuiw1r6xPvKovV5XWoDnTmtxpSXckbgEGo/S8pErJDNO\nTqcTJSUlmDdvnjSFBgAXLlzAtm3bcPfddyMpKQlnzpzBY489hsmTJ2P06NEAXPufs7OzMWfOHLzw\nwguoqqrCihUrsGTJEmnkvmjRImzcuBFPPPEEFixYgP3792P79u0oLb22SqG4uBhz587FhAkTMHHi\nRGzYsAEWiwWFhYUAXN9AHn74YRQXF6Nv374wm81YunQp8vLy/F5RR+qi1Wq5MrKHsNa+sT7yqL1e\ndqcGVQoaZAQaj9LykSskA6f3338fFRUVWLBggUe7Xq/H+++/Lw1iBg0ahFmzZmHFihVSH61Wi507\nd2Lx4sXIy8tDbGws5s2b53Hep6ysLJSWlqK4uBgvv/wyBg4ciNdff106ABIAZs+ejZqaGqxatQpV\nVVUYO3Ysdu/e7bEbbv369YiKisKsWbNgs9mQn5+PV199NRQlISIiIhUI+Xmc1I7ncVKPxsZGnDp1\nCjfffLNqp/yVgrX2jfWRJxLrJec8TslGgQdvcGDbea10sHU4BRpPd26vpPM48Vp1RG4Oh0M6lQWF\nFmvtG+sjj9rrpdcCWfGuf5Ug0HiUlo9cHDgRERER+YkDJyK32NhY6bg6Ci3W2jfWRx6116vGCrz2\nWRRqunei66ALNB6l5SNXSM8cThRJdDqddAFoCi3W2jfWRx6118vm0OBcffiPbWoXaDxKy0cuzjgR\nERER+YkDJyI3i8WC48ePS5d5oNBhrX1jfeRRe72SDALzhzqQZFDGIvhA41FaPnJx4ETkZrfbcfny\nZdjtXVxfgIKGtfaN9ZFH7fWKiQZuThKIUcjBNYHGo7R85OLAiYiIiMhPHDgRucXExGDs2LHSlc0p\ndFhr31gfedRer1ob8OaFKNTawh2JS6DxKC0fuSJ0oowo+AwGAzIzM8MdRq/AWvvG+sij9npZ2jQ4\nVq2cVWiBxqO0fOTijBMRERGRnzhwInJraWnBJ598gpaWCL5sd4RgrX1jfeRRe70S9AL3ZDqQoFfG\nKrRA41FaPnJx4ETkZrPZcOHCBdhsEbrjPYKw1r6xPvKovV7xOmBqukC8LtyRuAQaj9LykYsDJyIi\nIiI/ceBE5GY0GjFs2DAYjcZwh6J6rLVvrI88aq9XQyuw62sNGlrDHYlLoPEoLR+5NEKIyNzJqBAN\nDQ1ISEhAfX09zGZzuMMhIqIIMPip0nCHEFG+er4g6PfZ3c9vzjgRERER+YkDJyI3q9WK8+fPw2q1\nhjsU1WOtfWN95FF7veJ1ArenORGvU8YOokDjUVo+cnHgRORmtVrx6aefqvbNV0lYa99YH3nUXq8E\nPfDTwU4k6MMdiUug8SgtH7k4cCIiIiLyEwdORG56vR4ZGRnQ6yP0a1AEYa19Y33kUXu9LHag7IoG\nFnu4I3EJNB6l5SMXV9UFiKvqiIhILq6qk4er6oiIiIgiUHS4AyBSitbWVtTU1KB///6qnfJXCtba\nN9ZHnnDVq6dmjWK0AsMSBMrrNWhxaHrkMUMZj9LykYszTkRuzc3N+Pjjj9Hc3BzuUFSPtfaN9ZFH\n7fVKMgKFw5xIUsiJ0QONR2n5yMWBExEREZGfOHAicouOjkb//v0RHc092KHGWvvG+sij9nrZHMDn\ndRrYHOGOxCXQeJSWj1xcVRcgrqojIopcXN0WGbiqjoiIiCgCceBE5NbW1oarV6+ira0t3KGoHmvt\nG+sjj9rrpY8SGBwnoI9Sxg6iQONRWj5yceBE5NbU1IRDhw6hqakp3KGoHmvtG+sjj9rrlRwDPDbK\ngeSYcEfiEmg8SstHLg6ciIiIiPzEgRORW1RUFOLj4xEVxZdFqLHWvrE+8qi9XnYnUNns+lcJAo1H\nafnIFfRn2Zo1a6DRaDx+hg8fLv3darViyZIlSEpKQlxcHGbNmoUrV6543EdFRQUKCgpgMpmQnJyM\n5cuXd9p3/eGHH2LcuHEwGAy44YYbsGXLlk6xbNq0CYMHD4bRaERubi4++ugjj7/7Ewv1HmazGT/8\n4Q+5OrIHsNa+sT7yqL1eV1o0eP5v0bjSooyzbAcaj9LykSskw/ORI0eisrJS+jl8+LD0t8ceewx/\n/vOf8cc//hEHDhzA5cuXce+990p/dzgcKCgoQGtrK44ePYrf/e532LJlC1atWiX1uXjxIgoKCjB1\n6lScPn0ay5Ytw8KFC7Fnzx6pz1tvvYXi4mKsXr0aJ0+exJgxY5Cfn4/q6mq/YyEiIiLqKOjncVqz\nZg3effddnD59utPf6uvr0b9/f2zbtg0/+9nPAADnzp3DiBEjUFZWhltuuQW7du3CjBkzcPnyZaSk\npAAANm/ejCeffBI1NTXQ6/V48sknUVpaik8++US67/vvvx91dXXYvXs3ACA3Nxc5OTl45ZVXAABO\npxODBg3C0qVL8dRTT/kViz94Hif1cDqdsNlsMBgMqp3yVwrW2jfWR55A6hUJ53HSagTidECTHXCI\n8M/SBBpPd26vpPM4heQ0q19++SXS09NhNBqRl5eH5557DhkZGThx4gTsdjumT58u9R0+fDgyMjKk\nwUpZWRlGjRolDZoAID8/H4sXL8ann36Km2++GWVlZR730d5n2bJlAFwXfDxx4gSefvpp6e9RUVGY\nPn06ysrKAMCvWLyx2Wyw2WzS7w0NDQCAuro6OJ1OGAwGxMTESH1bWloAADqdDrGxsQAAu90Oi8UC\nANBqtYiPjwfgmm1rbGyU4m3fkEII1NfXS4+ZmJgo/b++vh7tY1+z2Sy9aTQ0NMDpdO1AjouLk86o\n29TUJO32NJlM0gUxm5ub0draCgAwGo0wGl0XEbJarbBarQCg+txsNhsOHDiAW2+9FTqdTlW5KW27\nORwOHD58GFOmTEF0dLSqcgvGdmtsbMTJkycxZcoUJCYmqiq3UGy3hoYGHDhwAOPGjZP6+ZvbwFhX\ne3UL0Op0fYj3NwoYtK7bfmeFdCHaPnqBWJ37PluBRrur3awTMLuvLdxoB+pbXe2x0QJ9DK72ljbg\nO5ur3aAV6O++TlurA6i2utp1UQIp7pVmDgFUNrva000Cj4924ndfRqG6BfjGcm2wMcAkoHH/Wtl8\nbSCSEiOgc48hg51bmglYPtohxSM3t35GgcKhTrx4Rot/WAQGxErpdJmb0+kMyXOyO4I+cMrNzcWW\nLVswbNgwVFZWYu3atZg0aRI++eQTVFVVQa/XezyhASAlJQVVVVUAgKqqKo9BU/vf2//mq09DQwNa\nWlpQW1sLh8Phtc+5c+ek+7heLN4899xzWLt2baf2I0eOwGQyYciQIbjpppukx2ifeUtPT0dOTg4A\noLa2VhrA9enTB5MnTwYAWCwWHDhwAIBr4+bn5wNwnaOkvR0AfvKTn0j/P3z4sPREueOOO6Q3o48/\n/lh6c5k0aRL69u0LADhz5gxqamoAABMmTMCAAQMAAOXl5aioqADg2tV6ww03AAC++uorlJeXA4Dq\ncxs4cCAA4Ntvv8UXX3yhqtyUtt3Gjh0r9VdbbsHabh2pLbdQbDcAOHnypOzclo92Xfdj/VktvnKf\nzWBWlhMjEl0DqpLyKJy+6vr0zh/oRF6Kq/2dr6LwYaWr/dYUJ+4a5Gr/4LIG715yjUxG9RV4YIjr\nA/7Udxps+cLVnhUnsDjb1X6xEdjwieujOMkAKZ46G7D6pKu9fQA070bXbf5f2bWP7l+OdMDo/nXV\nCS3qXeMDFA51IM2EkOXWMR65uTW2SncBvfZau6/cbDZb0J+T7W1yhfySK3V1dcjMzMRLL72EmJgY\nFBYWeszYAEBOTg6mTZuG559/Hr/4xS9w6dIlj+OVmpubERsbi127duHOO+/E0KFDUVhY6DGjVFpa\nihkzZqClpQVXr17FgAEDcPToUeTl5Ul9li9fjkOHDuHYsWPYtm3bdWPxxtuM06BBg3Dp0iWYzWbV\nfgMG1Pvtvj231tZWHD58GBMnTuSMUw/MOB07dgw/+MEPoNVqVZVbMLZbU1MTTp8+jUmTJiEhIUFV\nuYViu9XX1+PQoUMYO3Ys4uLiZOV298sHASh7xmmgyYlfjnTiD3+PQrVVE/YZpwEmgV+OdOAtdzxy\nc0syCDw4xInffKrF5Wb4NeN08Nd3B/05WV1djZSUFGXsqusoMTERQ4cOxfnz5/GjH/0Ira2tqKur\n83hStwcPAKmpqZ1Wv7WvdOvY5/ur36qrq2E2m2E0GtGvXz9otVqvfTrex/Vi8cZgMMBgMHjN8/uF\n76qvTqfrNNMFuN4cvLVrNBqv7QCQkJDgtb2rJ0H7m8r3mUwmmEymTu0dn2QdqTG3mJgYFBR0vR89\nknNrp6Tt5qvWQGTn1q672y0xMVGaAQXUldv3BSO3hIQEzJgxw2s87X/3xmw2e3xQt6uxej/uprZV\ng9rWzu0Ndg0a7J3bLW0aWLyczNzm0OAbS+d2u9N7+zfNUXjiuPdjt/7R7D3WrlasBSO3fzRr8ORx\n78MHf3L7xqLB365ey8db//bHadfx2LVgPie7I+RHHTY1NeHChQtIS0vD+PHjodPpsG/fPunvX3zx\nBSoqKqSZoby8PJw9e9Zj9dvevXthNpuRnZ0t9el4H+192u9Dr9dj/PjxHn2cTif27dsn9fEnFiIi\nIqKOgj7j9Pjjj2PmzJnIzMzE5cuXsXr1ami1WjzwwANISEjAww8/jOLiYvTt2xdmsxlLly5FXl6e\ndDD2HXfcgezsbMyZMwcvvPACqqqqsGLFCixZskT6VrJo0SJs3LgRTzzxBBYsWID9+/dj+/btKC29\ntjqiuLgYc+fOxYQJEzBx4kRs2LABFosFhYWFAOBXLEREREQdBX3G6ZtvvsEDDzyAYcOG4b777kNS\nUhKOHTuG/v37AwDWr1+PGTNmYNasWZg8eTJSU1Pxpz/9Sbq9VqvFzp07odVqkZeXh4ceeghz587F\nM888I/XJyspCaWkp9u7dizFjxmDdunV4/fXXPQ4SnD17NtatW4dVq1Zh7NixOH36NHbv3u2xG+56\nsVDvUldXhx07dqCuri7coagea+0b6yOP2us1MFbg5bw2aQVguAUaj9LykSvoM05/+MMffP7daDRi\n06ZN2LRpU5d9MjMz8d577/m8n6lTp+LUqVM++xQVFaGoqCigWIiIiIja8cxqRERERH4K+ekI1I5n\nDlcPIQTa2toQHR0Njcb7yhMKDtbaN9ZHnkDqFQlnDtdAQK91Le8XCP/zIdB4unN71Z85nCgSaTQa\n6fxNFFqstW+sjzxqr5eABjbH9fv1lEDjUVo+cnFXHREREZGfOHAicmtoaMCePXuk6w9S6LDWvrE+\n8qi9XmkmgbXj2pBmUsaRNYHGo7R85OLAicjN6XTCarVKp/Kn0GGtfWN95FF7vbQaINHg+lcJAo1H\nafnIxYETERERkZ+4qi5AXFWnHg6HAxaLBbGxsdBqtde/AXUba+0b6yNPIPWKhFV1uiiBJAPwnc11\nzbdwCzSe7tyeq+qIFEir1XLw20NYa99YH3nUXi+7U4OqlnBHcU2g8SgtH7m4q46IiIjITxw4Ebk1\nNjbi4MGDaGxsDHcoqsda+8b6yKP2eiUbBZbd1IZkozKOrAk0HqXlIxcHTkRuDocDtbW1cDgi+Mxs\nEYK19o31kUft9dJrgax4179KEGg8SstHLg6ciIiIiPzEVXUB4qo69bDb7aitrUWfPn1UffkGJWCt\nfWN95Bn2653IihO42KSBzRH+VWfBZtAKReUXaDzduT1X1REpkE6nQ3JycrjD6BVYa99YH3lsDg3O\n1Yd/QBEqSssv0HiUlo9c3FVHRERE5CcOnIjcLBYLjh8/DovFEu5QVI+19o31kSfJIDB/qANJBnUe\neaK0/AKNR2n5yMWBE5Gb3W7H5cuXYbfbwx2K6rHWvrE+8sREAzcnCcSo9OATpeUXaDxKy0cuDpyI\niIiI/MSBE5FbTEwMxo4di5iYmHCHonqstW+sjzy1NuDNC1GotYU7ktBQWn6BxqO0fOSK0IkyouAz\nGAzIzMwMdxi9AmvtG+sjj6VNg2PVkbtK63qUll+g8SgtH7k440RERETkJw6ciNxaWlrwySefoKUl\ngi/bHSFYa99YH3kS9AL3ZDqQoI/MVVrXo7T8Ao1HafnIxYETkZvNZsOFCxdgs0XojvcIwlr7xvrI\nE68DpqYLxKv0JOtKyy/QeJSWj1wcOBERERH5iQMnIjej0Yhhw4bBaDSGOxTVY619Y33kaWgFdn2t\nQUNruCMJDaXlF2g8SstHLl7kN0C8yC8RUXgNfqo03CFQiCnpIr+ccSIiIiLyEwdORG5WqxXnz5+H\n1WoNdyiqx1r7xvrIE68TuD3NiXidOnegKC2/QONRWj5yceBE5Ga1WvHpp5/yw6oHsNa+sT7yJOiB\nnw52IkEf7khCQ2n5BRqP0vKRi2cOJyKisAvkOKWBsUEMhOg6OHAictPr9cjIyIBeH6FfgyIIa+1b\npNYnXAdpW+xA2RUNLPawPHzIKS2/QONRWj5ycVVdgLiqjojIhavbKFRUvaruueeeQ05ODuLj45Gc\nnIx77rkH5eXlHn1uv/12aDQaj59FixZ59KmoqEBBQQFMJhOSk5OxfPlytLW1efT58MMPMW7cOBgM\nBtxwww3YsmVLp3g2bdqEwYMHw2g0Ijc3Fx999JHH361WK5YsWYKkpCTExcVh1qxZuHLlSnCKQURE\nRKoS9F11Bw4cwJIlS5CTk4O2tjb86le/wh133IHPPvsMsbHXdkQ/8sgjeOaZZ6TfTSaT9H+Hw4GC\nggKkpqbi6NGjqKysxNy5c6HT6fAf//EfAICLFy+ioKAAixYtwu9//3vs27cPCxcuRFpaGvLz8wEA\nb731FoqLi7F582bk5uZiw4YNyM/PR3l5OZKTkwEAjz32GEpLS/HHP/4RCQkJKCoqwr333osjR44E\nuzSkcK2traipqUH//v0jbhdJpOktte7uDEyMVuD9R29WfX2CJUYrMCxBoLxegxaHJtzhBJ3S8gs0\nHqXlI1fQZ5x2796N+fPnY+TIkRgzZgy2bNmCiooKnDhxwqOfyWRCamqq9NNxmuwvf/kLPvvsM2zd\nuhVjx47FXXfdhWeffRabNm1Ca6vrVKObN29GVlYW1q1bhxEjRqCoqAg/+9nPsH79eul+XnrpJTzy\nyCMoLCxEdnY2Nm/eDJPJhDfeeAMAUF9fj9/+9rd46aWX8MMf/hDjx49HSUkJjh49imPHjgW7NKRw\nzc3N+Pjjj9Hc3BzuUFSPtfYtyQjWR4YkI1A4zIkklZ5oXWn5BRqP0vKRK+QHh9fX1wMA+vbt69H+\n+9//Hlu3bkVqaipmzpyJlStXSrNOZWVlGDVqFFJSUqT++fn5WLx4MT799FPcfPPNKCsrw/Tp0z3u\nMz8/H8uWLQPg+kZ74sQJPP3009Lfo6KiMH36dJSVlQEATpw4Abvd7nE/w4cPR0ZGBsrKynDLLbd0\nysdms3lceLOhoQEAUFdXB6fTCYPBgJiYGKlv+9XNdTqdNONmt9thsVgAAFqtFvHx8QBcM22NjY1S\nrO2DSSGEVEcASExM9Khv+2FqZrMZUVFRUlxOpxMAEBcXh+ho16ZuamqSdnmaTCbp22xzc7M0KDUa\njdKlHqxWq7QkWu25tbPb7airq1NVbkrbbg6HQ+qvttw6brf+RgGD1nXb76yQvl330QvEui9wWt8K\nNNpd7WadgFkPJMd4HnqqxNy62m7Xyw0AGu1AfaurPTZaoI/75dfSBnxnc7UbtAL93R+srQ6gY5nx\n3wAAFiZJREFU2upq10UJpLg2ORwCqGy+NmPRsW7fWK61DzAJaNy/VjYDDuH6JSVGQOeePqhuAVqd\nrvbubrdQ5aaB8MhPCbl1jEdubv2M17aTBgIDOqyK7Co3p9MZkvfJ7gjpwMnpdGLZsmW47bbbcNNN\nN0ntDz74IDIzM5Geno4zZ87gySefRHl5Of70pz8BAKqqqjwGTQCk36uqqnz2aWhoQEtLC2pra+Fw\nOLz2OXfunHQfer3e482jvU/743zfc889h7Vr13ZqP3LkCEwmE4YMGSLlWlVVhdOnTwMA0tPTkZOT\nAwCora2VBm99+vTB5MmTAQAWiwUHDhwA4Nq47bsc29rapHYA+MlPfiL9//Dhw9IT5Y477pA+RD7+\n+GPpjXPSpEnSwPXMmTOoqakBAEyYMAEDBgwAAJSXl6OiogIAMHLkSNxwww0AgK+++ko6Rk3tuQ0e\nPBj9+/fH1atXpeeIWnJT2nabMGEC+vfvj+joaNXl1nG7zcpyYkSi60OipDwKp6+6PgXyBzqRl+Jq\nf+erKHxY6Wq/NcWJuwa52mNiYqQPBCXm1tV28ye3Dy5r8O4l16f3qL4CDwxxfQie+k6DLV+42rPi\nBBZnu9ovNgIbPnHVIskALB/tGnjX2YDVJ6NhcwDldcC8G51SPv+v7NrH2y9HOmB0/7rqhBb17muk\nFQ51IM19lMj6s1p81YSAt1uwcwMAp3uc0Z5fuHOzOVyDtPZ45ObW0Ap8XqeBzQHotdfafeVms9mC\n/j7Z3iZXSFfVLV68GLt27cLhw4cxcODALvvt378f06ZNw/nz5zFkyBD84he/wKVLl7Bnzx6pT3Nz\nM2JjY7Fr1y7ceeedGDp0KAoLCz1mlEpLSzFjxgy0tLTg6tWrGDBgAI4ePYq8vDypz/Lly3Ho0CEc\nO3YM27ZtQ2FhoccMEgDk5ORg2rRpeP755zvF6m3GadCgQbh06RLMZrPivwGr+ds9c2NuSsstZ83O\nbn+73/v4tG7nduOvdnY5c3G9b/c7l/6g29tt8FOlYZ2V8WfmIlJnnHp7bgd/fXfQ30uqq6uRkpIi\ne1VdyGacioqKsHPnThw8eNDnoAkAcnNzAUAaOKWmpnZa/da+0q19Bik1NbXT6rfq6mqYzWYYjUb0\n69cPWq3Wa5+O99Ha2oq6ujqPN8eOfb7PYDB47NZpl5iY2KnwXfXV6XSdZrkA1xuft3aNRuO1HQAS\nEhK8tnf1JIiLi/PabjKZPA7Qb9fxSdYRc7uGuXlibtfUWL0f+FrbqkGtlyvDN9g1aHCf22bE2v1e\nb+sfDb6xdG4VXbQDwD/cH2Tfz13udvMnt44sbRpY2jq32xzeY7U7u5/b911p8d4eyHbriLldE2hu\n7YMmILjvJd0R9IPDhRAoKirCO++8g/379yMrK+u6t2mfgk5LSwMA5OXl4ezZs6iurpb67N27F2az\nGdnZ2VKfffv2edzP3r17pdklvV6P8ePHe/RxOp3Yt2+f1Gf8+PHQ6XQefb744gtUVFR4zFJR79DW\n1oarV692Ou0FBR9r7Zs+SmBwnIA+iqfZ84fa66W0/AKNR2n5yBX0GaclS5Zg27Zt2LFjB+Lj46Vj\nhRISEhATE4MLFy5g27ZtuPvuu5GUlIQzZ87gsccew+TJkzF69GgArv3r2dnZmDNnDl544QVUVVVh\nxYoVWLJkifSNctGiRdi4cSOeeOIJLFiwAPv378f27dtRWnpt+W9xcTHmzp2LCRMmYOLEidiwYQMs\nFgsKCwulmB5++GEUFxejb9++MJvNWLp0KfLy8rweGE7q1tTUhEOHDmHKlCldzjhQcLDWviXHAI+N\ncuDFM9ouv42HSiSexDKc9eoJSssv0HiUlo9cQR84vfbaawBcJ7nsqKSkBPPnz4der8f7778vDWIG\nDRqEWbNmYcWKFVJfrVaLnTt3YvHixcjLy0NsbCzmzZvncd6nrKwslJaWori4GC+//DIGDhyI119/\nXToIEgBmz56NmpoarFq1ClVVVRg7dix2797tsRtu/fr1iIqKwqxZs2Cz2ZCfn49XX3012GUhIiIi\nFQj6wOl6x5oPGjTIY1VHVzIzM/Hee+/57DN16lScOnXKZ5+ioiIUFRV1+Xej0YhNmzZh06ZN142J\n1C0qKgrx8fEe+9IpNFhr3+xO14G+duf1+5L666W0/AKNR2n5yMVr1QWI16ojoq5E4m4vIiVS9bXq\niIiIiNSKAyciN6fTiZaWFun8IBQ6rLVvWo1Agl5Aq+EOAX+ovV5Kyy/QeJSWj1wcOBG5NTQ04C9/\n+Yt0GR0KHdbatzQT8Mz4a2d+Jt/UXi+l5RdoPErLRy4OnIiIiIj8xIETkZtGo0F0dDQ0Gu9n1qXg\nYa19EwKwtrn+petTe72Ull+g8SgtH7m4qi5AXFVHRF3hqjqi4OCqOiIiIqIIFLKL/BIRqQFnjYio\nI844EbnV1dVhx44dqKurC3coqsda+zYwVuDlvDYMjOWRFP5Qe72Ull+g8SgtH7k4cCIiIiLyEwdO\nRERERH7iqroAcVWdeggh0NbWxmXyIdR+vJAGAnot0OoABEJf60BW5ITjGKeerk+kU3u9lJZfoPF0\n5/ZKWlXHg8OJ3DQaDXQ6XbjD6BHhPuBZQAObo+ceL9z5ytXT9Yl0aq+X0vILNB6l5SMXB05EESrS\nBgNERGrAY5yI3BoaGrBnzx5eP60HpJkE1o5rQ5qJRwp4w/rIo/Z6KS2/QONRWj5yccaJyM3pdMJq\ntcLpdPbYY/bWWSOtBkg0uP6lzlgfedReL6XlF2g8SstHLg6ciALUWwc/RES9EVfVBYir6tTD4XDA\nYrEgNjYWWq3W79tx4CSfLkogyQB8ZwPszgj92hlCrI88aq+X0vILNJ7u3J6r6ogUSKvVcvDbQ+xO\nDapawh2FcrE+8qi9XkrLL9B4lJaPXDw4nIiIiMhPHDgRuTU2NuLgwYNobGwMdyiql2wUWHZTG5KN\nPFLAG9ZHHrXXS2n5BRqP0vKRi7vqiOA6TmlgrMDy0Q7cteEAvrGE/zgCNdNrgax417/UGesjj9rr\npbT8Ao1HafnIxRknIiIiIj9x4ETkVmMFXvssCjXWcEeifqy1b6yPPGqvl9LyCzQepeUjF3fVEbnZ\nHBqcq+cuup7AWvvG+sij9nopLb9A41FaPnJxxomIiIjIT5xxItUI9ESUSQaBmZlO/PlSFL6zRe63\noUjAWvvG+sij9nopLb9A41FaPnJxxonILSYauDlJIIZfJ0KOtfaN9ZFH7fVSWn6BxqO0fOTiwImI\niIjITxE63qNQC2S3VyiuKdQTam3AmxeiUGsLdyTqx1r7xvrIo/Z6KS2/QONRWj5yceBE5GZp0+BY\ndeTtb49ErLVvrI88aq+X0vILNB6l5SMXB06kKIEe4E1ERBRKHDi5bdq0CS+++CKqqqowZswYbNy4\nERMnTgx3WAHhIESeBL3A1DQnPqiMQn1r5H4bigSstW+sjzxqr5fS8gs0HqXlIxcPDgfw1ltvobi4\nGKtXr8bJkycxZswY5Ofno7q6OtyhUQ+K1wFT0wXideGORP1Ya99YH3nUXi+l5RdoPErLRy7OOAF4\n6aWX8Mgjj6CwsBAAsHnzZpSWluKNN97AU0895dHXZrPBZrt2RFt9fT0A4Ouvv0Z8fDwMBgNiYmKk\nvi0tLQAAnU6H2NhYAIDdbofFYgEAaLVaxMfHAwAcDgcaGxsBAFFRUTCbzQAAIYT0OACQmJjo8fhC\nuK4wbTabERXlGgs3NDQgVet6jBorYHe6RvX9jAJ693D5qg2wOlztiXoBk/vZ0GAHmuyu9njdtSd3\nUxvQ4P52YIoWSNS72q0O4Kr7XBx6rcAtv97uytMJ1Fhd7boogf5GV3+HAK60uNo1EEgzXauvs8M5\nPdJiBDTuX6+0AA7h+iXZKBDtziGYubVZgeZmB3T2KKRqNV5z62dAt3O73By+3PzZbj2Zm6ZVoLnZ\niTarFn01UFVuwdhufTTX6uO0aVSVGxD87damFWhudqCPJgpt7teuWnIDAIfWieZmp5RfuHP7fr3l\n5paAa89vYYNfz8m6ujqPzzen0wkAiIuLQ3S0K/Cmpia0tbW5am8yQa93Fb+5uRmtra0AAKPRCKPR\nFUhNTQ0ASJ+h/tIIubdQmdbWVphMJrz99tu45557pPZ58+ahrq4OO3bs8Oi/Zs0arF27tqfDJCIi\nohD4+uuvMXDgQL/79/oZp2+//RYOhwMpKSke7SkpKTh37lyn/k8//TSKi4ul351OJ65evYqkpCRM\nnDgRx48f9/l4OTk5Xfbx9TcKrD7+3LahoQGDBg3C119/Lc32BeOxewO59fl+rf25fVd91LhtfD0X\nuyPUr51wv68Fu149qSfem4L92gm03krZXkIINDY2Ij09Xdbtev3AqStCCGg0mk7tBoMBBoPBo619\n15lWq73uk8BXH39u35sFUh85tzWbzZ36ctv41t36tNc6kNeOmreNt+did4T6taOU97Vg1asn9cR7\nU6heO4HWWwnbKyEhQfZtev3B4f369YNWq8WVK1c82qurqzvNQl3PkiVLAurjz+17s0DqE2htuW18\n64n6dtWH2+b6Qv3a4fta9/G1E3l6/TFOAJCbm4uJEydi48aNAFy73zIyMlBUVNTp4HBSr4aGBiQk\nJKC+vj7s34LUjrX2jfWRR+31Ulp+gcajtHzk0q5Zs2ZNuIMIN7PZjBUrViAjIwMGgwErV67E6dOn\n8dvf/hZxcXHhDo96kFarxe233y6t0qDQYa19Y33kUXu9lJZfoPEoLR85OOPk9sorr0gnwBw7dix+\n85vfIDc3N9xhERERkYJw4ERERETkp15/cDgRERGRvzhwIiIiIvITB05EREREfuLAiYjCZvDgwdiw\nYUO4w4gYrBdR+HHgRL3CwYMHMXPmTKSnp0Oj0eDdd98Nd0i9AuveNdbGu95cF6XlvmbNGmg0Go+f\n4cOHe+17vdiFEFi1ahXS0tIQExOD6dOn48svv+yJNIKOAyfqFSwWC8aMGYNXXnkl3KH0Kqx711gb\n73pzXZSY+8iRI1FZWSn9HD582Gu/68X+wgsv4De/+Q1ee+01/PWvf0VsbCzy8/NhtVpDGX5oCKJe\nBoB45513PNoyMzPFs88+K+bMmSNiY2NFRkaG2LFjh6iurhY//vGPRWxsrBg1apQ4fvx4mKKOfF3V\n/d///d9FYWGhiIuLE4MGDRL//d//HaYIw8dbba5cuSJmzJghjEajGDx4sNi6davIzMwU69evD1OU\nPS+Yr9W3335bZGdnC71eLzIzM8V//dd/9WQqsn0/97Vr14qbbrqpU78xY8aIlStXhiSG1atXizFj\nxnj9W2FhoSgoKPBoa21tFf369esUu9PpFKmpqeLFF1+U2urq6oTBYBBvvvmmEEKIqVOniiVLlnjc\nX3V1tdDpdGLfvn3BSikoOONE5LZ+/XrcdtttOHXqFAoKCjBnzhzMnTsXDz30EE6ePIkhQ4Zg7ty5\nEDz1WVCtW7cOEyZMwKlTp/Doo49i8eLFOHfuXLjDCrv58+fj66+/xgcffIC3334br776Kqqrq8Md\nliLIfa2eOHEC9913H+6//36cPXsWa9aswcqVK7Fly5bwJiLDggUL8Nlnn+H48eNS26lTp3DmzBnM\nnz8/ZI/75ZdfIj09Hf/0T/+Ef/7nf0ZFRQUAYOHChdi9ezcqKyulvjt37kRLS0un+7h48SKqqqow\nffp0qS0hIQG5ubkoKyuT7m/btm2w2WxSn61bt2LAgAGYOnVqqNLrnnCP3Ih6Grr4FvvQQw9Jv1dW\nVgoAHt/kysrKBABRWVnZY7GqiT91dzqdIjk5Wbz22ms9HV5Yfb825eXlAoD46KOPpLbPP/9cAOCM\nUzdeqw8++KD40Y9+5HE/y5cvF9nZ2SGMPjDecr/rrrvE4sWLpd+XLl0qbr/99pDF8N5774nt27eL\nv/3tb2L37t0iLy9PZGRkiIaGBiGEENnZ2eI///M/pf4zZ84U8+fP7xT7kSNHBABx+fJlj/v/+c9/\nLu677z4hhBBWq1X07dtXvPXWW9LfR48eLdasWROy/LqLM05EbqNHj5b+n5KSAgAYNWpUpzZ+6w+u\njnXXaDRITU3t9TX+/PPPER0djfHjx0ttw4cPR2JiYhijUg65r9XPP/8ct912m8d93Hbbbfjyyy/h\ncDhCHW7QPPLII3jzzTdhtVrR2tqKbdu2YcGCBSF7vLvuugs///nPMXr0aOTn5+O9995DXV0dtm/f\nDsA1S1RSUgIAuHLlCnbt2iUrHiEENBoNAMBgMOChhx7CG2+8AQA4efIkzp49G9LZtO7iwInITafT\nSf9vfzF7a3M6nT0bmMp1rDHgqnNvr7Hg7mCf5L5WO35At4vEGs+cORMGgwHvvPMO/vznP8Nut2PW\nrFk99viJiYkYOnQozp8/DwCYO3cu/v73v6OsrAxbt25FVlYWJk2a1Ol2qampAFyDq46qq6ulQS7g\nGojt3bsX33zzDUpKSjBt2jRkZmaGMKPu4cCJiEhhRowYgba2Npw4cUJqKy8vR11dXRijilzZ2dmd\nVoMdPXoUQ4cOhVarDVNU8kVHR2PevHkoKSlBSUkJ7r//fphMph57/KamJly4cAFpaWkAgKSkJNxz\nzz0oKSnBli1bUFhY6PV2WVlZSE1Nxb59+6S2hoYG/PWvf0VeXp7UNmrUKEyYMAH/+7//G/LZtEBE\nhzsAop7Q1NQkfUsCXAcrnj59Gn379kVGRkYYI1M31r1rvmozbNgw3HnnnfiXf/kXvPbaa4iOjsay\nZcsQExMTxoh7RiieM//6r/+KnJwcPPvss5g9ezbKysrwyiuv4NVXXw1W2EHhT+4LFy7EiBEjAABH\njhwJaTyPP/44Zs6ciczMTFy+fBmrV6+GVqvFAw88IPVZuHAhZsyYgba2NowfPx6nT5/2GvuyZcvw\nb//2b7jxxhuRlZWFlStXIj09Hffcc4/HYy5cuBBFRUUwmUz46U9/GtL8ui28h1gR9YwPPvhAAOj0\nM2/ePCGE8LrMG987wPHixYsCgDh16lRPhh7RulP3MWPGiNWrV/d8sD3serWprKwUBQUFwmAwiIyM\nDPF///d/veJ0BKF6rbafjkCn04mMjAyPpfFKcb3c202aNKlHDmyfPXu2SEtLE3q9XgwYMEDMnj1b\nnD9/3qOP0+kUmZmZIjc312fsTqdTrFy5UqSkpAiDwSCmTZsmysvLOz1mY2OjMJlM4tFHHw15ft2l\nESICd/QSERH1QkII3HjjjXj00UdRXFwc7nBgsViQnp6OkpIS3HvvvQHf31dffYUhQ4bg+PHjGDdu\nXBAiDD7uqiMiIooANTU1+MMf/oCqqqoujyfqKU6nE99++y3WrVuHxMRE/PjHPw7o/ux2O7777jus\nWLECt9xyi2IHTQAHTkRERBEhOTkZ/fr1w//8z/+gT58+YY2loqICWVlZGDhwILZs2YLo6MCGE0eO\nHMHUqVMxdOhQvP3220GKMjS4q46IiIjITzwdAREREZGfOHAiIiIi8hMHTkRERER+4sCJiIiIyE8c\nOBERERH5iQMnIiIiIj9x4ERERETkJw6ciIiIiPz0/wEyaVrU9myFJQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<matplotlib.figure.Figure at 0x7fdfbc5f3518>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plot_loghist(time_to_data.loc[time_to_data['time_to_edit'] > 0]['time_to_edit'], 30)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Same vertical lines in the histogram at 1 minute, 1 hour, 1 day, 1 month, 1 year, 5 years, and 10 years.\n",
+    "\n",
+    "## Summary, and what's next?\n",
+    "\n",
+    "So far, we've learned that SDC edits (in 2019) most frequently occur right around the file upload. There's a cutoff around the 1 hour mark in the distribution of those edits. A second part of the distribution starts around the 1 month mark, but increases significantly around the 1 year mark and onwards. There are definitely older files that are being edited with structured data. Looks like there's roughly 500,000 SDC edits to >= 1 year old files.\n",
+    "\n",
+    "For non-SDC edits (again made in 2019 so far), we see the majority of them being done to quite old files, often a year or older. There's about 7,000,000 edits to those. Activity on newly uploaded files seems to be quite limited, there's a clear jump up at 24 hours. Note that we've removed bots from these, so this means that commonists are making a lot of maintenance edits.\n",
+    "\n",
+    "This also means that it'll be difficult for us to learn to what extent commonists are making substantially more of these edits now that SDC is available. The goal for SDC was a 10% increase. 500,000 vs 7,000,000 suggests that might be the case, though. I'll think about whether a straightforward comparison of those two numbers is reasonable or not."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Time horizon for SDC edits\n",
+    "\n",
+    "We see that for both SDC edits and non-SDC edits, one month is a reasonable threshold for longer-term maintenance edits. If the file is older than that, it means they're no longer making updates to the file. Let's make a comparison of number of SDC edits from 30–60 days 60–90 days, 90–120 days, 120–150 days, and 150–180 days, just to get an idea if there's actually an increase there or what we're seeing is the increase in the bucket size."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 17,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "sdc_horizon_query = '''\n",
+    "WITH sdc_edits AS (\n",
+    "    SELECT unix_timestamp(event_timestamp) - unix_timestamp(page_creation_timestamp) AS time_to_edit\n",
+    "    FROM commons_edits\n",
+    "    WHERE event_comment REGEXP \"^...wbsetclaim-create:.*?Special:EntityPage/(P\\\\\\\\d+)\"\n",
+    "    OR event_comment REGEXP \"^...wbsetlabel-add:\"\n",
+    ")\n",
+    "SELECT \n",
+    "    SUM(IF(time_to_edit BETWEEN 3600*24*30 AND 3600*24*60, 1, 0)) AS num_30,\n",
+    "    SUM(IF(time_to_edit BETWEEN 3600*24*60 AND 3600*24*90, 1, 0)) AS num_60,\n",
+    "    SUM(IF(time_to_edit BETWEEN 3600*24*90 AND 3600*24*120, 1, 0)) AS num_90,\n",
+    "    SUM(IF(time_to_edit BETWEEN 3600*24*120 AND 3600*24*150, 1, 0)) AS num_120,\n",
+    "    SUM(IF(time_to_edit BETWEEN 3600*24*150 AND 3600*24*180, 1, 0)) AS num_150\n",
+    "FROM sdc_edits\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 18,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>num_30</th>\n",
+       "      <th>num_60</th>\n",
+       "      <th>num_90</th>\n",
+       "      <th>num_120</th>\n",
+       "      <th>num_150</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>9333</td>\n",
+       "      <td>10063</td>\n",
+       "      <td>8213</td>\n",
+       "      <td>4741</td>\n",
+       "      <td>5208</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   num_30  num_60  num_90  num_120  num_150\n",
+       "0    9333   10063    8213     4741     5208"
+      ]
+     },
+     "execution_count": 18,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "sdc_horizons = spark.sql(sdc_horizon_query).toPandas()\n",
+    "sdc_horizons"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "We see that there's a substantial amount of edits in the second month, similar to the third month, and the fourth is not far behind. Because of this, I find choosing a 30 day threshold to seem reasonable, otherwise we'd have to go much further, at 120 days, and that seems unreasonable."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Comparison of number of SDC and non-SDC edits\n",
+    "\n",
+    "We'll look at this overall so far in 2019, as well as edits done in Q1, Q2, and Q3 specifically."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 42,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overall_stats_query = '''\n",
+    "SELECT\n",
+    "    SUM(IF(event_timestamp >= \"2019-01-01\" AND event_timestamp < \"2019-04-01\"\n",
+    "           AND edit_type = \"sdc\", 1, 0)) AS sdc_q1,\n",
+    "    SUM(IF(event_timestamp >= \"2019-01-01\" AND event_timestamp < \"2019-04-01\"\n",
+    "           AND edit_type = \"non-sdc\", 1, 0)) AS non_sdc_q1,\n",
+    "    SUM(IF(event_timestamp >= \"2019-04-01\" AND event_timestamp < \"2019-07-01\"\n",
+    "           AND edit_type = \"sdc\", 1, 0)) AS sdc_q2,\n",
+    "    SUM(IF(event_timestamp >= \"2019-04-01\" AND event_timestamp < \"2019-07-01\"\n",
+    "           AND edit_type = \"non-sdc\", 1, 0)) AS non_sdc_q2,\n",
+    "    SUM(IF(event_timestamp >= \"2019-07-01\" AND event_timestamp < \"2019-10-01\"\n",
+    "           AND edit_type = \"sdc\", 1, 0)) AS sdc_q3,\n",
+    "    SUM(IF(event_timestamp >= \"2019-07-01\" AND event_timestamp < \"2019-10-01\"\n",
+    "           AND edit_type = \"non-sdc\", 1, 0)) AS non_sdc_q3,\n",
+    "    SUM(IF(event_timestamp >= \"2019-10-01\" AND event_timestamp < \"2020-01-01\"\n",
+    "           AND edit_type = \"sdc\", 1, 0)) AS sdc_q4,\n",
+    "    SUM(IF(event_timestamp >= \"2019-10-01\" AND event_timestamp < \"2020-01-01\"\n",
+    "           AND edit_type = \"non-sdc\", 1, 0)) AS non_sdc_q4,\n",
+    "    SUM(IF(event_timestamp >= \"2019-01-01\" AND event_timestamp < \"2020-01-01\"\n",
+    "           AND edit_type = \"sdc\", 1, 0)) AS sdc_overall,\n",
+    "    SUM(IF(event_timestamp >= \"2019-01-01\" AND event_timestamp < \"2020-01-01\"\n",
+    "           AND edit_type = \"non-sdc\", 1, 0)) AS non_sdc_overall\n",
+    "FROM (\n",
+    "    SELECT \"sdc\" AS edit_type, event_timestamp, \n",
+    "           unix_timestamp(event_timestamp) - unix_timestamp(page_creation_timestamp) AS time_to_edit\n",
+    "    FROM commons_edits\n",
+    "    WHERE event_comment REGEXP \"^...wbsetclaim-create:.*?Special:EntityPage/(P\\\\\\\\d+)\"\n",
+    "    OR event_comment REGEXP \"^...wbsetlabel-add:\"\n",
+    "    UNION ALL\n",
+    "    SELECT \"non-sdc\" AS edit_type, event_timestamp,\n",
+    "           unix_timestamp(event_timestamp) - unix_timestamp(page_creation_timestamp) AS time_to_edit\n",
+    "    FROM commons_edits\n",
+    "    WHERE event_comment NOT REGEXP \"^...wbsetclaim-create:.*?Special:EntityPage/(P\\\\\\\\d+)\"\n",
+    "    AND event_comment NOT REGEXP \"^...wbsetlabel-add:\"\n",
+    "    AND revision_text_bytes_diff > 0\n",
+    "    AND (revision_is_identity_reverted = false\n",
+    "         OR revision_seconds_to_identity_revert > 48 * 60 * 60)\n",
+    "    AND revision_is_identity_revert = false\n",
+    ")\n",
+    "WHERE time_to_edit >= 60*60*24*30\n",
+    "'''"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 43,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "overall_stats = spark.sql(overall_stats_query).toPandas()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 44,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>sdc_q1</th>\n",
+       "      <th>non_sdc_q1</th>\n",
+       "      <th>sdc_q2</th>\n",
+       "      <th>non_sdc_q2</th>\n",
+       "      <th>sdc_q3</th>\n",
+       "      <th>non_sdc_q3</th>\n",
+       "      <th>sdc_q4</th>\n",
+       "      <th>non_sdc_q4</th>\n",
+       "      <th>sdc_overall</th>\n",
+       "      <th>non_sdc_overall</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>29168</td>\n",
+       "      <td>2439163</td>\n",
+       "      <td>65853</td>\n",
+       "      <td>2098908</td>\n",
+       "      <td>120114</td>\n",
+       "      <td>2475043</td>\n",
+       "      <td>161799</td>\n",
+       "      <td>1683223</td>\n",
+       "      <td>376934</td>\n",
+       "      <td>8696337</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "   sdc_q1  non_sdc_q1  sdc_q2  non_sdc_q2  sdc_q3  non_sdc_q3  sdc_q4  \\\n",
+       "0   29168     2439163   65853     2098908  120114     2475043  161799   \n",
+       "\n",
+       "   non_sdc_q4  sdc_overall  non_sdc_overall  \n",
+       "0     1683223       376934          8696337  "
+      ]
+     },
+     "execution_count": 44,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "overall_stats"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "What proportions does that gives us on a per-quarter basis and overall?\n",
+    "\n",
+    "### Q1 2019"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 38,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    1.2\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "round(100 * overall_stats['sdc_q1'] / (overall_stats['sdc_q1'] + overall_stats['non_sdc_q1']), 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q2 2019"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 39,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    3.0\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 39,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "round(100 * overall_stats['sdc_q2'] / (overall_stats['sdc_q2'] + overall_stats['non_sdc_q2']), 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q3 2019"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 40,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    4.6\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 40,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "round(100 * overall_stats['sdc_q3'] / (overall_stats['sdc_q3'] + overall_stats['non_sdc_q3']), 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Q4 2019\n",
+    "\n",
+    "So far in Q4, meaning the months of October and November."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 45,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    8.8\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 45,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "round(100 * overall_stats['sdc_q4'] / (overall_stats['sdc_q4'] + overall_stats['non_sdc_q4']), 1)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### 2019 overall"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 41,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "0    4.2\n",
+       "dtype: float64"
+      ]
+     },
+     "execution_count": 41,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "round(100 * overall_stats['sdc_overall'] / (overall_stats['sdc_overall'] + overall_stats['non_sdc_overall']), 1)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "PySpark - YARN (large)",
+   "language": "python",
+   "name": "spark_yarn_pyspark_large"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.3"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/T231952-part-3.ipynb
+++ b/T231952-part-3.ipynb
@@ -264,14 +264,15 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 18,
+   "execution_count": 113,
    "metadata": {},
    "outputs": [],
    "source": [
     "bot_caption_add_query = '''\n",
     "SELECT\n",
     "  SUM(IF(size(event_user_is_bot_by_historical) > 0, 1, 0)) AS num_bot_edits,\n",
-    "  SUM(IF(size(event_user_is_bot_by_historical) = 0, 1, 0)) AS num_nonbot_edits\n",
+    "  SUM(IF(size(event_user_is_bot_by_historical) = 0, 1, 0)) AS num_nonbot_edits,\n",
+    "  SUM(IF(size(event_user_is_bot_by) > 0, 1, 0)) AS num_current_bot_edits\n",
     "FROM wmf.mediawiki_history\n",
     "WHERE snapshot = \"2019-10\"\n",
     "AND wiki_db = \"commonswiki\"\n",
@@ -284,7 +285,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 19,
+   "execution_count": 114,
    "metadata": {},
    "outputs": [],
    "source": [
@@ -296,7 +297,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 20,
+   "execution_count": 115,
    "metadata": {},
    "outputs": [
     {
@@ -322,6 +323,7 @@
        "      <th></th>\n",
        "      <th>num_bot_edits</th>\n",
        "      <th>num_nonbot_edits</th>\n",
+       "      <th>num_current_bot_edits</th>\n",
        "    </tr>\n",
        "  </thead>\n",
        "  <tbody>\n",
@@ -329,17 +331,18 @@
        "      <td>0</td>\n",
        "      <td>103</td>\n",
        "      <td>1500692</td>\n",
+       "      <td>100</td>\n",
        "    </tr>\n",
        "  </tbody>\n",
        "</table>\n",
        "</div>"
       ],
       "text/plain": [
-       "   num_bot_edits  num_nonbot_edits\n",
-       "0            103           1500692"
+       "   num_bot_edits  num_nonbot_edits  num_current_bot_edits\n",
+       "0            103           1500692                    100"
       ]
      },
-     "execution_count": 20,
+     "execution_count": 115,
      "metadata": {},
      "output_type": "execute_result"
     }


### PR DESCRIPTION
This adds a notebook analyzing when edits to files occur relative
to when the file was created, for edits in 2019. We look at both
SDC and other types of edits, and identify 30 days as a reasonable
threshold for what "later" means. Then measures proportion of edits
by type (SDC and non-SDC edits).

Minor modifications to part 2 to also count bot edits.